### PR TITLE
truncate and fixing a typo

### DIFF
--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -718,13 +718,13 @@ namespace Microsoft.FSharp.Collections
                 inherit SeqComponentFactory<'T,'T> ()
                 override __.Create<'V> (_result:Result<'V>) (next:SeqComponent<'T,'V>) : SeqComponent<'T,'V> = upcast Skip (count, next) 
 
-            and SkipWhileFactory<'T> (perdicate:'T->bool) =
+            and SkipWhileFactory<'T> (predicate:'T->bool) =
                 inherit SeqComponentFactory<'T,'T> ()
-                override __.Create<'V> (_result:Result<'V>) (next:SeqComponent<'T,'V>) : SeqComponent<'T,'V> = upcast SkipWhile (perdicate, next) 
+                override __.Create<'V> (_result:Result<'V>) (next:SeqComponent<'T,'V>) : SeqComponent<'T,'V> = upcast SkipWhile (predicate, next) 
 
-            and TakeWhileFactory<'T> (perdicate:'T->bool) =
+            and TakeWhileFactory<'T> (predicate:'T->bool) =
                 inherit SeqComponentFactory<'T,'T> ()
-                override __.Create<'V> (result:Result<'V>) (next:SeqComponent<'T,'V>) : SeqComponent<'T,'V> = upcast TakeWhile (perdicate, result, next) 
+                override __.Create<'V> (result:Result<'V>) (next:SeqComponent<'T,'V>) : SeqComponent<'T,'V> = upcast TakeWhile (predicate, result, next) 
 
             and TakeFactory<'T> (count:int) =
                 inherit SeqComponentFactory<'T,'T> ()

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -904,24 +904,12 @@ namespace Microsoft.FSharp.Collections
                         Helpers.avoidTailCall (next.ProcessNext input)
 
             and Take<'T,'V> (takeCount:int, result:Result<'V>, next:SeqComponent<'T,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                let mutable count = 0
-
-                override __.ProcessNext (input:'T) : bool = 
-                    if count < takeCount then
-                        count <- count + 1
-                        if count = takeCount then
-                            result.StopFurtherProcessing ()
-                        next.ProcessNext input
-                    else
-                        result.StopFurtherProcessing ()
-                        false
+                inherit Truncate<'T, 'V>(takeCount, result, next)
 
                 interface ISeqComponent with
-                    override __.OnComplete () =
-                        if count < takeCount then
-                            let x = takeCount - count
+                    override this.OnComplete () =
+                        if this.Count < takeCount then
+                            let x = takeCount - this.Count
                             invalidOpFmt "tried to take {0} {1} past the end of the seq"
                                 [|SR.GetString SR.notEnoughElements; x; (if x=1 then "element" else "elements")|]
                         (Helpers.UpcastISeqComponent next).OnComplete ()
@@ -943,15 +931,17 @@ namespace Microsoft.FSharp.Collections
                     result.Current <- input
                     true
 
-            and Truncate<'T,'V> (takeCount:int, result:Result<'V>, next:SeqComponent<'T,'V>) =
+            and Truncate<'T,'V> (truncateCount:int, result:Result<'V>, next:SeqComponent<'T,'V>) =
                 inherit SeqComponent<'T,'V>(next)
 
                 let mutable count = 0
 
+                member __.Count = count
+
                 override __.ProcessNext (input:'T) : bool = 
-                    if count < takeCount then
+                    if count < truncateCount then
                         count <- count + 1
-                        if count = takeCount then
+                        if count = truncateCount then
                             result.StopFurtherProcessing ()
                         next.ProcessNext input
                     else


### PR DESCRIPTION
Sorry I was out because of hurricane issues. I'll hopefully be able to start working on this more.

Truncate seems to be the same as Take except it won't throw. Perhaps we might want to have Take inherit from Truncate, the only difference being the ISeqComponent interface implementation.
