### PR TITLE
except

### DIFF
--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -697,6 +697,10 @@ namespace Microsoft.FSharp.Collections
             and DistinctByFactory<'T,'Key when 'Key: equality> (keyFunction:'T-> 'Key) =
                 inherit SeqComponentFactory<'T,'T> ()
                 override __.Create<'V> (_result:Result<'V>) (next:SeqComponent<'T,'V>) : SeqComponent<'T,'V> = upcast DistinctBy (keyFunction, next) 
+            
+            and ExceptFactory<'T when 'T: equality> (itemsToExclude: seq<'T>) =
+                inherit SeqComponentFactory<'T,'T> ()
+                override __.Create<'V> (_result:Result<'V>) (next:SeqComponent<'T,'V>) : SeqComponent<'T,'V> = upcast Except (itemsToExclude, next) 
 
             and FilterFactory<'T> (filter:'T->bool) =
                 inherit SeqComponentFactory<'T,'T> ()
@@ -787,6 +791,17 @@ namespace Microsoft.FSharp.Collections
 
                 override __.ProcessNext (input:'T) : bool = 
                     if hashSet.Add(keyFunction input) then
+                        Helpers.avoidTailCall (next.ProcessNext input)
+                    else
+                        false
+
+            and Except<'T,'V when 'T: equality> (itemsToExclude: seq<'T>, next:SeqComponent<'T,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                let cached = lazy(HashSet(itemsToExclude, HashIdentity.Structural))
+
+                override __.ProcessNext (input:'T) : bool = 
+                    if cached.Value.Add input then
                         Helpers.avoidTailCall (next.ProcessNext input)
                     else
                         false
@@ -2311,17 +2326,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Except")>]
         let except (itemsToExclude: seq<'T>) (source: seq<'T>) =
             checkNonNull "itemsToExclude" itemsToExclude
-            checkNonNull "source" source
-
-            seq {
-                use e = source.GetEnumerator()
-                if e.MoveNext() then
-                    let cached = HashSet(itemsToExclude, HashIdentity.Structural)
-                    let next = e.Current
-                    if (cached.Add next) then yield next
-                    while e.MoveNext() do
-                        let next = e.Current
-                        if (cached.Add next) then yield next }
+            source |> seqFactory (SeqComposer.ExceptFactory itemsToExclude)
 
         [<CompiledName("ChunkBySize")>]
         let chunkBySize chunkSize (source : seq<_>) =


### PR DESCRIPTION
I use lazy on `cached` to avoid creating the `HashSet` unless we actually process anything (i.e. if our input is empty we shouldn't have to generate a `HashSet`). I did a little bit of testing comparing it to if I set cached to null initially and then initializing it after running `ProcessNext` and it seems to make little difference.
