### PR TITLE
making identity more efficient

### DIFF
--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -532,7 +532,7 @@ namespace Microsoft.FSharp.Collections
 
             and IdentityFactory<'T> () =
                 inherit SeqComponentFactory<'T,'T> ()
-                override __.Create<'V> (_result:Result<'V>) (next:SeqComponent<'T,'V>) : SeqComponent<'T,'V> = next.CreateMap id
+                override __.Create<'V> (_result:Result<'V>) (next:SeqComponent<'T,'V>) : SeqComponent<'T,'V> = upcast Identity (next)
                 override __.IsIdentity = true
 
             and MapFactory<'T,'U> (map:'T->'U) =
@@ -666,6 +666,12 @@ namespace Microsoft.FSharp.Collections
                         Helpers.avoidTailCall (next.ProcessNext (map input))
                     else
                         false
+
+            and Identity<'T,'V> (next:SeqComponent<'T,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                override __.ProcessNext (input:'T) : bool = 
+                    Helpers.avoidTailCall (next.ProcessNext input)
 
             and Map<'T,'U,'V> (map:'T->'U, next:SeqComponent<'U,'V>) =
                 inherit SeqComponent<'T,'V>(next)


### PR DESCRIPTION
So I noticed something that was not good while doing some testing your change to `ofArray`. So my initial test seemed good:

```
let testArr = [|1L..10000000L|]

let work () = 
    testArr
    |> Seq.ofArray
    |> Seq.map (fun n -> n * 5L)
    |> Seq.filter (fun n -> n % 7L <> 0L)
    |> Seq.map (fun n -> n / 11L)
    |> Seq.sum
```

Before:
    64bit: 253 
    32bit: 381

After: 
    64bit: 163
    32bit: 330

Everything is a bit faster. Then I thought about testing ofArray just by itself without any of the other functions.

```
let testArr = [|1L..10000000L|]

let work () = 
    testArr
    |> Seq.ofArray
    |> Seq.sum
```

Before:
    64bit: 70
    32bit: 70

After: 
    64bit: 113
    32bit: 153

Which is a decent amount slower with the new method. I decided to check maybe since sum isn't part of the chain that is the reason. But there was some difference especially for 32bit.

```
let work () = 
    testArr
    |> Seq.ofArray
    |> Seq.fold (Checked.(+)) 0L
```

Before:
    64bit: 93
    32bit: 85

After: 
    64bit: 67
    32bit: 113

This change makes it so we don't call the `id` function and just pass the result. Here's the new numbers on the 2nd test case:

New: 
    64bit: 102
    32bit: 125

So it helps somewhat, but there is still some differential.
