### PR TITLE
without fold

### DIFF
--- a/src/fsharp/FSharp.Core/seq.fsi
+++ b/src/fsharp/FSharp.Core/seq.fsi
@@ -26,14 +26,9 @@ namespace Microsoft.FSharp.Collections
                 abstract ProcessNext : input:'T -> bool
                 interface ISeqComponent
 
-            type Fold<'T> =
-                inherit SeqConsumer<'T,'T>
-                new : folder:('T->'T->'T) * initialState:'T -> Fold<'T>
-                member Folded : 'T
-
             [<AbstractClass>]
             type SeqEnumerable<'T> =
-                abstract member ForEach<'a when 'a :> SeqConsumer<'T,'T>> : f:(ISeqPipeline->'a) -> 'a
+                abstract member ForEach<'a when 'a :> SeqConsumer<'T,'T>> : g: ('T -> 'T -> 'T) -> state: ref<'T> -> unit
 
         /// <summary>Returns a new sequence that contains the cartesian product of the two input sequences.</summary>
         /// <param name="source1">The first sequence.</param>


### PR DESCRIPTION
This is a way to implement `ForEach` without having to have a separate Fold type, my benchmarking seems to indicate its a bit faster than your implementation. 

That said I haven't implemented `fold` itself because I think I need another generic parameter on everything for that to work and I didn't have time today, but I imagine that it should also work.

Check it out if you get a chance. This is just an experiment, but it might be the way forward.
