### PR TITLE
findIndex/tryFindIndex and a fix to Concat when there are side effects

### DIFF
--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1111,10 +1111,7 @@ namespace Microsoft.FSharp.Collections
                     let mutable state = SeqProcessNextStates.NotStarted
                     let main = sources.GetEnumerator ()
 
-                    let mutable active =
-                        if main.MoveNext ()
-                        then main.Current.GetEnumerator ()
-                        else EmptyEnumerators.Element
+                    let mutable active = EmptyEnumerators.Element
 
                     let rec moveNext () =
                         if active.MoveNext () then


### PR DESCRIPTION
Your implementation of `concat` caused the test `SingletonCollectWithSideEffects` to fail. This fixes it as well as implements findIndex/tryFindIndex.
