### PR TITLE
Reduce the diff on seq.fs so that it is easier to review on GitHub

### DIFF
--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -84,6 +84,18 @@
     <Compile Include="collections.fs">
       <Link>Collections/collections.fs</Link>
     </Compile>
+        <Compile Include="seqcore.fsi">
+      <Link>Collections/seqcore.fsi</Link>
+    </Compile>
+    <Compile Include="seqcore.fs">
+      <Link>Collections/seqcore.fs</Link>
+    </Compile>
+    <Compile Include="seqcomposer.fsi">
+      <Link>Collections/seqcomposer.fsi</Link>
+    </Compile>
+    <Compile Include="seqcomposer.fs">
+      <Link>Collections/seqcomposer.fs</Link>
+    </Compile>
     <Compile Include="seq.fsi">
       <Link>Collections/seq.fsi</Link>
     </Compile>

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1,411 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 namespace Microsoft.FSharp.Collections
-    #nowarn "52" // The value has been copied to ensure the original is not mutated by this operation
-
-    open System
-    open System.Diagnostics
-    open System.Collections
-    open System.Collections.Generic
-    open Microsoft.FSharp.Core
-    open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
-    open Microsoft.FSharp.Core.Operators
-    open Microsoft.FSharp.Control
-    open Microsoft.FSharp.Collections
-
-    module IEnumerator =
-
-      let noReset() = raise (new System.NotSupportedException(SR.GetString(SR.resetNotSupported)))
-      let notStarted() = raise (new System.InvalidOperationException(SR.GetString(SR.enumerationNotStarted)))
-      let alreadyFinished() = raise (new System.InvalidOperationException(SR.GetString(SR.enumerationAlreadyFinished)))
-      let check started = if not started then notStarted()
-      let dispose (r : System.IDisposable) = r.Dispose()
-
-      let cast (e : IEnumerator) : IEnumerator<'T> =
-          { new IEnumerator<'T> with
-                member x.Current = unbox<'T> e.Current
-            interface IEnumerator with
-                member x.Current = unbox<'T> e.Current :> obj
-                member x.MoveNext() = e.MoveNext()
-                member x.Reset() = noReset()
-            interface System.IDisposable with
-                member x.Dispose() =
-                    match e with
-                    | :? System.IDisposable as e -> e.Dispose()
-                    | _ -> ()   }
-
-      /// A concrete implementation of an enumerator that returns no values
-      [<Sealed>]
-      type EmptyEnumerator<'T>() =
-          let mutable started = false
-          interface IEnumerator<'T> with
-                member x.Current =
-                  check started
-                  (alreadyFinished() : 'T)
-
-          interface System.Collections.IEnumerator with
-              member x.Current =
-                  check started
-                  (alreadyFinished() : obj)
-              member x.MoveNext() =
-                  if not started then started <- true
-                  false
-              member x.Reset() = noReset()
-          interface System.IDisposable with
-                member x.Dispose() = ()
-
-      let Empty<'T> () = (new EmptyEnumerator<'T>() :> IEnumerator<'T>)
-
-      let readAndClear r =
-          lock r (fun () -> match !r with None -> None | Some _ as res -> r := None; res)
-
-      let generateWhileSome openf compute closef : IEnumerator<'U> =
-          let started = ref false
-          let curr = ref None
-          let state = ref (Some(openf()))
-          let getCurr() =
-              check !started
-              match !curr with None -> alreadyFinished() | Some x -> x
-          let start() = if not !started then (started := true)
-
-          let dispose() = readAndClear state |> Option.iter closef
-          let finish() = (try dispose() finally curr := None)
-          {  new IEnumerator<'U> with
-                 member x.Current = getCurr()
-             interface IEnumerator with
-                 member x.Current = box (getCurr())
-                 member x.MoveNext() =
-                     start()
-                     match !state with
-                     | None -> false (* we started, then reached the end, then got another MoveNext *)
-                     | Some s ->
-                         match (try compute s with e -> finish(); reraise()) with
-                         | None -> finish(); false
-                         | Some _ as x -> curr := x; true
-
-                 member x.Reset() = noReset()
-             interface System.IDisposable with
-                 member x.Dispose() = dispose() }
-
-      [<Sealed>]
-      type Singleton<'T>(v:'T) =
-          let mutable started = false
-          interface IEnumerator<'T> with
-                member x.Current = v
-          interface IEnumerator with
-              member x.Current = box v
-              member x.MoveNext() = if started then false else (started <- true; true)
-              member x.Reset() = noReset()
-          interface System.IDisposable with
-              member x.Dispose() = ()
-
-      let Singleton x = (new Singleton<'T>(x) :> IEnumerator<'T>)
-
-      let EnumerateThenFinally f (e : IEnumerator<'T>) =
-          { new IEnumerator<'T> with
-                member x.Current = e.Current
-            interface IEnumerator with
-                member x.Current = (e :> IEnumerator).Current
-                member x.MoveNext() = e.MoveNext()
-                member x.Reset() = noReset()
-            interface System.IDisposable with
-                member x.Dispose() =
-                    try
-                        e.Dispose()
-                    finally
-                        f()
-          }
-
-
-namespace Microsoft.FSharp.Core.CompilerServices
-
-    open System
-    open System.Diagnostics
-    open Microsoft.FSharp.Core
-    open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
-    open Microsoft.FSharp.Core.Operators
-    open Microsoft.FSharp.Control
-    open Microsoft.FSharp.Collections
-    open Microsoft.FSharp.Primitives.Basics
-    open System.Collections
-    open System.Collections.Generic
-
-    module RuntimeHelpers =
-
-        [<Struct; NoComparison; NoEquality>]
-        type internal StructBox<'T when 'T : equality>(value:'T) =
-            member x.Value = value
-            static member Comparer =
-                let gcomparer = HashIdentity.Structural<'T>
-                { new IEqualityComparer<StructBox<'T>> with
-                       member __.GetHashCode(v) = gcomparer.GetHashCode(v.Value)
-                       member __.Equals(v1,v2) = gcomparer.Equals(v1.Value,v2.Value) }
-
-        let inline checkNonNull argName arg =
-            match box arg with
-            | null -> nullArg argName
-            | _ -> ()
-
-        let mkSeq f =
-            { new IEnumerable<'U> with
-                member x.GetEnumerator() = f()
-              interface IEnumerable with
-                member x.GetEnumerator() = (f() :> IEnumerator) }
-                
-        [<NoEquality; NoComparison>]
-        type EmptyEnumerable<'T> =
-            | EmptyEnumerable
-            interface IEnumerable<'T> with
-                member x.GetEnumerator() = IEnumerator.Empty<'T>()
-            interface IEnumerable with
-                member x.GetEnumerator() = (IEnumerator.Empty<'T>() :> IEnumerator)
-
-        let Generate openf compute closef =
-            mkSeq (fun () -> IEnumerator.generateWhileSome openf compute closef)
-
-        let GenerateUsing (openf : unit -> ('U :> System.IDisposable)) compute =
-            Generate openf compute (fun (s:'U) -> s.Dispose())
-
-        let EnumerateFromFunctions opener moveNext current =
-            Generate
-                opener
-                (fun x -> if moveNext x then Some(current x) else None)
-                (fun x -> match box(x) with :? System.IDisposable as id -> id.Dispose() | _ -> ())
-
-        // A family of enumerators that can have additional 'finally' actions added to the enumerator through
-        // the use of mutation. This is used to 'push' the disposal action for a 'use' into the next enumerator.
-        // For example,
-        //    seq { use x = ...
-        //          while ... }
-        // results in the 'while' loop giving an adjustable enumerator. This is then adjusted by adding the disposal action
-        // from the 'use' into the enumerator. This means that we avoid constructing a two-deep enumerator chain in this
-        // common case.
-        type IFinallyEnumerator =
-            abstract AppendFinallyAction : (unit -> unit) -> unit
-
-        /// A concrete implementation of IEnumerable that adds the given compensation to the "Dispose" chain of any
-        /// enumerators returned by the enumerable.
-        [<Sealed>]
-        type FinallyEnumerable<'T>(compensation: unit -> unit, restf: unit -> seq<'T>) =
-            interface IEnumerable<'T> with
-                member x.GetEnumerator() =
-                    try
-                        let ie = restf().GetEnumerator()
-                        match ie with
-                        | :? IFinallyEnumerator as a ->
-                            a.AppendFinallyAction(compensation)
-                            ie
-                        | _ ->
-                            IEnumerator.EnumerateThenFinally compensation ie
-                    with e ->
-                        compensation()
-                        reraise()
-            interface IEnumerable with
-                member x.GetEnumerator() = ((x :> IEnumerable<'T>).GetEnumerator() :> IEnumerator)
-
-        /// An optimized object for concatenating a sequence of enumerables
-        [<Sealed>]
-        type ConcatEnumerator<'T,'U when 'U :> seq<'T>>(sources: seq<'U>) =
-            let mutable outerEnum = sources.GetEnumerator()
-            let mutable currInnerEnum = IEnumerator.Empty()
-
-            let mutable started = false
-            let mutable finished = false
-            let mutable compensations = []
-
-            [<DefaultValue(false)>] // false = unchecked
-            val mutable private currElement : 'T
-
-            member x.Finish() =
-                finished <- true
-                try
-                    match currInnerEnum with
-                    | null -> ()
-                    | _ ->
-                        try
-                            currInnerEnum.Dispose()
-                        finally
-                            currInnerEnum <- null
-                finally
-                    try
-                        match outerEnum with
-                        | null -> ()
-                        | _ ->
-                            try
-                                outerEnum.Dispose()
-                            finally
-                                outerEnum <- null
-                    finally
-                        let rec iter comps =
-                            match comps with
-                            |   [] -> ()
-                            |   h::t ->
-                                    try h() finally iter t
-                        try
-                            compensations |> List.rev |> iter
-                        finally
-                            compensations <- []
-
-            member x.GetCurrent() =
-                IEnumerator.check started
-                if finished then IEnumerator.alreadyFinished() else x.currElement
-
-            interface IFinallyEnumerator with
-                member x.AppendFinallyAction(f) =
-                    compensations <- f :: compensations
-
-            interface IEnumerator<'T> with
-                member x.Current = x.GetCurrent()
-
-            interface IEnumerator with
-                member x.Current = box (x.GetCurrent())
-
-                member x.MoveNext() =
-                   if not started then (started <- true)
-                   if finished then false
-                   else
-                      let rec takeInner () =
-                        // check the inner list
-                        if currInnerEnum.MoveNext() then
-                            x.currElement <- currInnerEnum.Current
-                            true
-                        else
-                            // check the outer list
-                            let rec takeOuter() =
-                                if outerEnum.MoveNext() then
-                                    let ie = outerEnum.Current
-                                    // Optimization to detect the statically-allocated empty IEnumerables
-                                    match box ie with
-                                    | :? EmptyEnumerable<'T> ->
-                                         // This one is empty, just skip, don't call GetEnumerator, try again
-                                         takeOuter()
-                                    | _ ->
-                                         // OK, this one may not be empty.
-                                         // Don't forget to dispose of the enumerator for the inner list now we're done with it
-                                         currInnerEnum.Dispose()
-                                         currInnerEnum <- ie.GetEnumerator()
-                                         takeInner ()
-                                else
-                                    // We're done
-                                    x.Finish()
-                                    false
-                            takeOuter()
-                      takeInner ()
-
-                member x.Reset() = IEnumerator.noReset()
-
-            interface System.IDisposable with
-                member x.Dispose() =
-                    if not finished then
-                        x.Finish()
-
-        let EnumerateUsing (resource : 'T :> System.IDisposable) (rest: 'T -> #seq<'U>) =
-            (FinallyEnumerable((fun () -> match box resource with null -> () | _ -> resource.Dispose()),
-                               (fun () -> rest resource :> seq<_>)) :> seq<_>)
-
-        let mkConcatSeq (sources: seq<'U :> seq<'T>>) =
-            mkSeq (fun () -> new ConcatEnumerator<_,_>(sources) :> IEnumerator<'T>)
-
-        let EnumerateWhile (g : unit -> bool) (b: seq<'T>) : seq<'T> =
-            let started = ref false
-            let curr = ref None
-            let getCurr() =
-                IEnumerator.check !started
-                match !curr with None -> IEnumerator.alreadyFinished() | Some x -> x
-            let start() = if not !started then (started := true)
-
-            let finish() = (curr := None)
-            mkConcatSeq
-               (mkSeq (fun () ->
-                    { new IEnumerator<_> with
-                          member x.Current = getCurr()
-                       interface IEnumerator with
-                          member x.Current = box (getCurr())
-                          member x.MoveNext() =
-                               start()
-                               let keepGoing = (try g() with e -> finish (); reraise ()) in
-                               if keepGoing then
-                                   curr := Some(b); true
-                               else
-                                   finish(); false
-                          member x.Reset() = IEnumerator.noReset()
-                       interface System.IDisposable with
-                          member x.Dispose() = () }))
-
-        let EnumerateThenFinally (rest : seq<'T>) (compensation : unit -> unit)  =
-            (FinallyEnumerable(compensation, (fun () -> rest)) :> seq<_>)
-
-        let CreateEvent (add : 'Delegate -> unit) (remove : 'Delegate -> unit) (create : (obj -> 'Args -> unit) -> 'Delegate ) :IEvent<'Delegate,'Args> =
-            // Note, we implement each interface explicitly: this works around a bug in the CLR
-            // implementation on CompactFramework 3.7, used on Windows Phone 7
-            { new obj() with
-                  member x.ToString() = "<published event>"
-              interface IEvent<'Delegate,'Args>
-              interface IDelegateEvent<'Delegate> with
-                 member x.AddHandler(h) = add h
-                 member x.RemoveHandler(h) = remove h
-              interface System.IObservable<'Args> with
-                 member x.Subscribe(r:IObserver<'Args>) =
-                     let h = create (fun _ args -> r.OnNext(args))
-                     add h
-                     { new System.IDisposable with
-                          member x.Dispose() = remove h } }
-
-
-    [<AbstractClass>]
-    type GeneratedSequenceBase<'T>() =
-        let mutable redirectTo : GeneratedSequenceBase<'T> = Unchecked.defaultof<_>
-        let mutable redirect : bool = false
-
-        abstract GetFreshEnumerator : unit -> IEnumerator<'T>
-        abstract GenerateNext : next:byref<IEnumerable<'T>> -> int // 0 = Stop, 1 = Yield, 2 = Goto
-        abstract Close: unit -> unit
-        abstract CheckClose: bool
-        abstract LastGenerated : 'T
-
-        //[<System.Diagnostics.DebuggerNonUserCode; System.Diagnostics.DebuggerStepThroughAttribute>]
-        member x.MoveNextImpl() =
-             let active =
-                 if redirect then redirectTo
-                 else x
-             let mutable target = null
-             match active.GenerateNext(&target) with
-             | 1 ->
-                 true
-             | 2 ->
-                 match target.GetEnumerator() with
-                 | :? GeneratedSequenceBase<'T> as g when not active.CheckClose ->
-                     redirectTo <- g
-                 | e ->
-                     redirectTo <-
-                           { new GeneratedSequenceBase<'T>() with
-                                 member x.GetFreshEnumerator() = e
-                                 member x.GenerateNext(_) = if e.MoveNext() then 1 else 0
-                                 member x.Close() = try e.Dispose() finally active.Close()
-                                 member x.CheckClose = true
-                                 member x.LastGenerated = e.Current }
-                 redirect <- true
-                 x.MoveNextImpl()
-             | _ (* 0 *)  ->
-                 false
-
-        interface IEnumerable<'T> with
-            member x.GetEnumerator() = x.GetFreshEnumerator()
-        interface IEnumerable with
-            member x.GetEnumerator() = (x.GetFreshEnumerator() :> IEnumerator)
-        interface IEnumerator<'T> with
-            member x.Current = if redirect then redirectTo.LastGenerated else x.LastGenerated
-            member x.Dispose() = if redirect then redirectTo.Close() else x.Close()
-        interface IEnumerator with
-            member x.Current = box (if redirect then redirectTo.LastGenerated else x.LastGenerated)
-
-            //[<System.Diagnostics.DebuggerNonUserCode; System.Diagnostics.DebuggerStepThroughAttribute>]
-            member x.MoveNext() = x.MoveNextImpl()
-
-            member x.Reset() = raise <| new System.NotSupportedException()
-
-
-namespace Microsoft.FSharp.Collections
 
     open System
     open System.Diagnostics
@@ -419,6 +14,7 @@ namespace Microsoft.FSharp.Collections
     open Microsoft.FSharp.Control
     open Microsoft.FSharp.Collections
     open Microsoft.FSharp.Primitives.Basics
+    open Microsoft.FSharp.Collections.IEnumerator
 
     [<Sealed>]
     type CachedSeq<'T>(cleanup,res:seq<'T>) =
@@ -434,1300 +30,27 @@ namespace Microsoft.FSharp.Collections
     [<RequireQualifiedAccess>]
     [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
     module Seq =
-        module Composer =
-            open IEnumerator
-
-            module Internal =
-                type PipeIdx      = int
-                type ``PipeIdx?`` = Nullable<PipeIdx>
-                let emptyPipeIdx  = Nullable ()
-                let inline getPipeIdx (maybePipeIdx:``PipeIdx?``) = if maybePipeIdx.HasValue then maybePipeIdx.Value else 1
-                let inline makePipeIdx (pipeIdx:PipeIdx) = Nullable pipeIdx
-
-                type ICompletionChaining =
-                    abstract OnComplete : PipeIdx -> unit
-                    abstract OnDispose : unit -> unit
-
-                type IOutOfBand =
-                    abstract StopFurtherProcessing : PipeIdx -> unit
-
-                [<AbstractClass>]
-                type Consumer<'T,'U> () =
-                    abstract ProcessNext : input:'T -> bool
-
-                    abstract OnComplete : PipeIdx -> unit
-                    abstract OnDispose : unit -> unit
-
-                    default __.OnComplete _ = ()
-                    default __.OnDispose () = ()
-
-                    interface ICompletionChaining with
-                        member this.OnComplete terminatingIdx =
-                            this.OnComplete terminatingIdx
-
-                        member this.OnDispose () = 
-                            try this.OnDispose ()
-                            finally ()
-
-                [<Struct; NoComparison; NoEquality>]
-                type Values<'a,'b> =
-                    val mutable _1 : 'a
-                    val mutable _2 : 'b
-
-                    new (a:'a, b: 'b) = {
-                        _1 = a
-                        _2 = b
-                    }
-
-                [<Struct; NoComparison; NoEquality>]
-                type Values<'a,'b,'c> =
-                    val mutable _1 : 'a
-                    val mutable _2 : 'b
-                    val mutable _3 : 'c
-
-                    new (a:'a, b:'b, c:'c) = {
-                        _1 = a
-                        _2 = b
-                        _3 = c
-                    }
-
-                [<AbstractClass>]
-                type Folder<'T, 'U> =
-                    inherit Consumer<'T,'T>
-
-                    val mutable Value : 'U
-
-                    new (init) = {
-                        inherit Consumer<'T,'T>()
-                        Value = init
-                    }
-
-                type ISeqFactory<'T,'U> =
-                    abstract PipeIdx : PipeIdx
-                    abstract Create<'V> : IOutOfBand -> ``PipeIdx?`` -> Consumer<'U,'V> -> Consumer<'T,'V>
-
-                type ISeq<'T> =
-                    inherit IEnumerable<'T>
-                    abstract member Compose<'U> : (ISeqFactory<'T,'U>) -> ISeq<'U>
-                    abstract member ForEach<'consumer when 'consumer :> Consumer<'T,'T>> : f:((unit->unit)->'consumer) -> 'consumer
-
-            open Internal
-
-            module Helpers =
-                // used for performance reasons; these are not recursive calls, so should be safe
-                // ** it should be noted that potential changes to the f# compiler may render this function
-                // ineffictive **
-                let inline avoidTailCall boolean = match boolean with true -> true | false -> false
-
-                // The f# compiler outputs unnecessary unbox.any calls in upcasts. If this functionality
-                // is fixed with the compiler then these functions can be removed.
-                let inline upcastSeq (t:#ISeq<'T>) : ISeq<'T> = (# "" t : ISeq<'T> #)
-                let inline upcastFactory (t:#ISeqFactory<'T,'U>) : ISeqFactory<'T,'U> = (# "" t : ISeqFactory<'T,'U> #)
-                let inline upcastEnumerable (t:#IEnumerable<'T>) : IEnumerable<'T> = (# "" t : IEnumerable<'T> #)
-                let inline upcastEnumerator (t:#IEnumerator<'T>) : IEnumerator<'T> = (# "" t : IEnumerator<'T> #)
-                let inline upcastEnumeratorNonGeneric (t:#IEnumerator) : IEnumerator = (# "" t : IEnumerator #)
-                let inline upcastICompletionChaining (t:#ICompletionChaining) : ICompletionChaining = (# "" t : ICompletionChaining #)
-
-            open Helpers
-
-            type [<AbstractClass>] SeqComponentFactory<'T,'U> (pipeIdx:``PipeIdx?``) =
-                new() = SeqComponentFactory<'T,'U> (emptyPipeIdx)
-                
-                interface ISeqFactory<'T,'U> with
-                    member __.PipeIdx = getPipeIdx pipeIdx
-                    member __.Create<'V> (_:IOutOfBand) (_:``PipeIdx?``) (_:Consumer<'U,'V>) : Consumer<'T,'V> = failwith "library implementation error: Create on base factory should not be called"
-
-            and ComposedFactory<'T,'U,'V> private (first:ISeqFactory<'T,'U>, second:ISeqFactory<'U,'V>, secondPipeIdx:PipeIdx) =
-                inherit SeqComponentFactory<'T,'V> (makePipeIdx secondPipeIdx)
-
-                interface ISeqFactory<'T,'V> with
-                    member this.Create<'W> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'V,'W>) : Consumer<'T,'W> =
-                        first.Create outOfBand pipeIdx (second.Create outOfBand (makePipeIdx secondPipeIdx) next)
-
-                static member Combine (first:ISeqFactory<'T,'U>) (second:ISeqFactory<'U,'V>) : ISeqFactory<'T,'V> =
-                    ComposedFactory(first, second, first.PipeIdx+1) |> upcastFactory
-
-            and ChooseFactory<'T,'U> (filter:'T->option<'U>) =
-                inherit SeqComponentFactory<'T,'U> ()
-                interface ISeqFactory<'T,'U> with
-                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'T,'V> = upcast Choose (filter, next) 
-            
-            and DistinctFactory<'T when 'T: equality> () =
-                inherit SeqComponentFactory<'T,'T> ()
-                interface ISeqFactory<'T,'T> with
-                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast Distinct (next) 
-
-            and DistinctByFactory<'T,'Key when 'Key: equality> (keyFunction:'T-> 'Key) =
-                inherit SeqComponentFactory<'T,'T> ()
-                interface ISeqFactory<'T,'T> with
-                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast DistinctBy (keyFunction, next) 
-            
-            and ExceptFactory<'T when 'T: equality> (itemsToExclude: seq<'T>) =
-                inherit SeqComponentFactory<'T,'T> ()
-                interface ISeqFactory<'T,'T> with
-                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast Except (itemsToExclude, next) 
-
-            and FilterFactory<'T> (filter:'T->bool) =
-                inherit SeqComponentFactory<'T,'T> ()
-                interface ISeqFactory<'T,'T> with
-                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> =
-                        match next with
-                        | :? SeqComponent<'T,'V> as next -> upcast next.CreateFilter filter
-                        | _ -> upcast Filter (filter, next)
-
-            and IdentityFactory<'T> () =
-                inherit SeqComponentFactory<'T,'T> ()
-                static let singleton = IdentityFactory<'T>()
-                interface ISeqFactory<'T,'T> with
-                    member __.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = next
-                static member Instance = singleton
-
-            and MapFactory<'T,'U> (map:'T->'U) =
-                inherit SeqComponentFactory<'T,'U> ()
-                interface ISeqFactory<'T,'U> with
-                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'T,'V> =
-                        match next with
-                        | :? SeqComponent<'U,'V> as next -> upcast next.CreateMap map
-                        | _ -> upcast Map<_,_,_> (map, next)
-
-            and Map2FirstFactory<'First,'Second,'U> (map:'First->'Second->'U, input2:IEnumerable<'Second>) =
-                inherit SeqComponentFactory<'First,'U> ()
-                interface ISeqFactory<'First,'U> with
-                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'First,'V> = upcast Map2First (map, input2, outOfBand, next, getPipeIdx pipeIdx)
-
-            and Map2SecondFactory<'First,'Second,'U> (map:'First->'Second->'U, input1:IEnumerable<'First>) =
-                inherit SeqComponentFactory<'Second,'U> ()
-                interface ISeqFactory<'Second,'U> with
-                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'Second,'V> = upcast Map2Second (map, input1, outOfBand, next, getPipeIdx pipeIdx)
-
-            and Map3Factory<'First,'Second,'Third,'U> (map:'First->'Second->'Third->'U, input2:IEnumerable<'Second>, input3:IEnumerable<'Third>) =
-                inherit SeqComponentFactory<'First,'U> ()
-                interface ISeqFactory<'First,'U> with
-                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'First,'V> = upcast Map3 (map, input2, input3, outOfBand, next, getPipeIdx pipeIdx)
-
-            and MapiFactory<'T,'U> (mapi:int->'T->'U) =
-                inherit SeqComponentFactory<'T,'U> ()
-                interface ISeqFactory<'T,'U> with
-                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'T,'V> = upcast Mapi (mapi, next) 
-
-            and Mapi2Factory<'First,'Second,'U> (map:int->'First->'Second->'U, input2:IEnumerable<'Second>) =
-                inherit SeqComponentFactory<'First,'U> ()
-                interface ISeqFactory<'First,'U> with
-                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'First,'V> = upcast Mapi2 (map, input2, outOfBand, next, getPipeIdx pipeIdx)
-
-            and PairwiseFactory<'T> () =
-                inherit SeqComponentFactory<'T,'T*'T> ()
-                interface ISeqFactory<'T,'T*'T> with
-                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T*'T,'V>) : Consumer<'T,'V> = upcast Pairwise (next)
-
-            and ScanFactory<'T,'State> (folder:'State->'T->'State, initialState:'State) =
-                inherit SeqComponentFactory<'T,'State> ()
-                interface ISeqFactory<'T,'State> with
-                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'State,'V>) : Consumer<'T,'V> = upcast Scan<_,_,_> (folder, initialState, next)
-
-            and SkipFactory<'T> (count:int) =
-                inherit SeqComponentFactory<'T,'T> ()
-                interface ISeqFactory<'T,'T> with
-                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast Skip (count, next) 
-
-            and SkipWhileFactory<'T> (predicate:'T->bool) =
-                inherit SeqComponentFactory<'T,'T> ()
-                interface ISeqFactory<'T,'T> with
-                    member  this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast SkipWhile (predicate, next) 
-
-            and TakeWhileFactory<'T> (predicate:'T->bool) =
-                inherit SeqComponentFactory<'T,'T> ()
-                interface ISeqFactory<'T,'T> with
-                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast TakeWhile (predicate, outOfBand, next, getPipeIdx pipeIdx) 
-
-            and TakeFactory<'T> (count:int) =
-                inherit SeqComponentFactory<'T,'T> ()
-                interface ISeqFactory<'T,'T> with
-                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast Take (count, outOfBand, next, getPipeIdx pipeIdx) 
-            
-            and TailFactory<'T> () =
-                inherit SeqComponentFactory<'T,'T> ()
-                interface ISeqFactory<'T,'T> with
-                    member  this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast Tail<'T,'V> (next) 
-
-            and TruncateFactory<'T> (count:int) =
-                inherit SeqComponentFactory<'T,'T> ()
-                interface ISeqFactory<'T,'T> with
-                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast Truncate (count, outOfBand, next, getPipeIdx pipeIdx) 
-            
-            and WindowedFactory<'T> (windowSize:int) =
-                inherit SeqComponentFactory<'T, 'T[]> ()
-                interface ISeqFactory<'T, 'T[]> with
-                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T[],'V>) : Consumer<'T,'V> = upcast Windowed (windowSize, next) 
-
-            and [<AbstractClass>] SeqComponent<'T,'U> (next:ICompletionChaining) =
-                inherit Consumer<'T,'U>()
-
-                // Seq.init(Infinite)? lazily uses Current. The only Composer component that can do that is Skip
-                // and it can only do it at the start of a sequence
-                abstract Skipping : unit -> bool
-
-                abstract CreateMap<'S> : map:('S->'T) -> SeqComponent<'S,'U>
-                abstract CreateFilter  : filter:('T->bool) -> SeqComponent<'T,'U>
-
-                interface ICompletionChaining with
-                    member this.OnComplete terminatingIdx =
-                        this.OnComplete terminatingIdx
-                        next.OnComplete terminatingIdx
-                    member this.OnDispose () =
-                        try     this.OnDispose ()
-                        finally next.OnDispose ()
-
-                default __.Skipping () = false
-
-                default this.CreateMap<'S> (map:'S->'T)      = upcast Map<_,_,_> (map, this) 
-                default this.CreateFilter  (filter:'T->bool) = upcast Filter (filter, this) 
-
-            and Choose<'T,'U,'V> (choose:'T->option<'U>, next:Consumer<'U,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                override __.ProcessNext (input:'T) : bool =
-                    match choose input with
-                    | Some value -> avoidTailCall (next.ProcessNext value)
-                    | None -> false
-
-            and Distinct<'T,'V when 'T: equality> (next:Consumer<'T,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                let hashSet = HashSet<'T>(HashIdentity.Structural<'T>)
-
-                override __.ProcessNext (input:'T) : bool = 
-                    if hashSet.Add input then
-                        avoidTailCall (next.ProcessNext input)
-                    else
-                        false
-
-            and DistinctBy<'T,'Key,'V when 'Key: equality> (keyFunction: 'T -> 'Key, next:Consumer<'T,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                let hashSet = HashSet<'Key>(HashIdentity.Structural<'Key>)
-
-                override __.ProcessNext (input:'T) : bool = 
-                    if hashSet.Add(keyFunction input) then
-                        avoidTailCall (next.ProcessNext input)
-                    else
-                        false
-
-            and Except<'T,'V when 'T: equality> (itemsToExclude: seq<'T>, next:Consumer<'T,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                let cached = lazy(HashSet(itemsToExclude, HashIdentity.Structural))
-
-                override __.ProcessNext (input:'T) : bool = 
-                    if cached.Value.Add input then
-                        avoidTailCall (next.ProcessNext input)
-                    else
-                        false
-
-            and Filter<'T,'V> (filter:'T->bool, next:Consumer<'T,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                override this.CreateMap<'S> (map:'S->'T) = upcast MapThenFilter<_,_,_> (map, filter, next) 
-
-                override __.ProcessNext (input:'T) : bool = 
-                    if filter input then
-                        avoidTailCall (next.ProcessNext input)
-                    else
-                        false
-
-            and FilterThenMap<'T,'U,'V> (filter:'T->bool, map:'T->'U, next:Consumer<'U,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                override __.ProcessNext (input:'T) : bool = 
-                    if filter input then
-                        avoidTailCall (next.ProcessNext (map input))
-                    else
-                        false
-
-            and Map<'T,'U,'V> (map:'T->'U, next:Consumer<'U,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                override this.CreateFilter (filter:'T->bool) = upcast FilterThenMap (filter, map, next) 
-
-                override __.ProcessNext (input:'T) : bool = 
-                    avoidTailCall (next.ProcessNext (map input))
-
-            and Map2First<'First,'Second,'U,'V> (map:'First->'Second->'U, enumerable2:IEnumerable<'Second>, outOfBand:IOutOfBand, next:Consumer<'U,'V>, pipeIdx:int) =
-                inherit SeqComponent<'First,'V>(next)
-
-                let input2 = enumerable2.GetEnumerator ()
-                let map' = OptimizedClosures.FSharpFunc<_,_,_>.Adapt map
-
-                override __.ProcessNext (input:'First) : bool =
-                    if input2.MoveNext () then
-                        avoidTailCall (next.ProcessNext (map'.Invoke (input, input2.Current)))
-                    else
-                        outOfBand.StopFurtherProcessing pipeIdx
-                        false
-
-                override __.OnDispose () =
-                    input2.Dispose ()
-
-            and Map2Second<'First,'Second,'U,'V> (map:'First->'Second->'U, enumerable1:IEnumerable<'First>, outOfBand:IOutOfBand, next:Consumer<'U,'V>, pipeIdx:int) =
-                inherit SeqComponent<'Second,'V>(next)
-
-                let input1 = enumerable1.GetEnumerator ()
-                let map' = OptimizedClosures.FSharpFunc<_,_,_>.Adapt map
-
-                override __.ProcessNext (input:'Second) : bool =
-                    if input1.MoveNext () then
-                        avoidTailCall (next.ProcessNext (map'.Invoke (input1.Current, input)))
-                    else
-                        outOfBand.StopFurtherProcessing pipeIdx
-                        false
-
-                override __.OnDispose () =
-                    input1.Dispose ()
-
-            and Map3<'First,'Second,'Third,'U,'V> (map:'First->'Second->'Third->'U, enumerable2:IEnumerable<'Second>, enumerable3:IEnumerable<'Third>, outOfBand:IOutOfBand, next:Consumer<'U,'V>, pipeIdx:int) =
-                inherit SeqComponent<'First,'V>(next)
-
-                let input2 = enumerable2.GetEnumerator ()
-                let input3 = enumerable3.GetEnumerator ()
-                let map' = OptimizedClosures.FSharpFunc<_,_,_,_>.Adapt map
-
-                override __.ProcessNext (input:'First) : bool =
-                    if input2.MoveNext () && input3.MoveNext () then
-                        avoidTailCall (next.ProcessNext (map'.Invoke (input, input2.Current, input3.Current)))
-                    else
-                        outOfBand.StopFurtherProcessing pipeIdx
-                        false
-
-                override __.OnDispose () =
-                    try     input2.Dispose ()
-                    finally input3.Dispose ()
-
-            and MapThenFilter<'T,'U,'V> (map:'T->'U, filter:'U->bool, next:Consumer<'U,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                override __.ProcessNext (input:'T) : bool = 
-                    let u = map input
-                    if filter u then
-                        avoidTailCall (next.ProcessNext u)
-                    else
-                        false
-
-            and Mapi<'T,'U,'V> (mapi:int->'T->'U, next:Consumer<'U,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                let mutable idx = 0
-                let mapi' = OptimizedClosures.FSharpFunc<_,_,_>.Adapt mapi
-
-                override __.ProcessNext (input:'T) : bool = 
-                    idx <- idx + 1
-                    avoidTailCall (next.ProcessNext (mapi'.Invoke (idx-1, input)))
-
-            and Mapi2<'First,'Second,'U,'V> (map:int->'First->'Second->'U, enumerable2:IEnumerable<'Second>, outOfBand:IOutOfBand, next:Consumer<'U,'V>, pipeIdx:int) =
-                inherit SeqComponent<'First,'V>(next)
-
-                let mutable idx = 0
-                let input2 = enumerable2.GetEnumerator ()
-                let mapi2' = OptimizedClosures.FSharpFunc<_,_,_,_>.Adapt map
-
-                override __.ProcessNext (input:'First) : bool =
-                    if input2.MoveNext () then
-                        idx <- idx + 1
-                        avoidTailCall (next.ProcessNext (mapi2'.Invoke (idx-1, input, input2.Current)))
-                    else
-                        outOfBand.StopFurtherProcessing pipeIdx
-                        false
-
-                override __.OnDispose () =
-                    input2.Dispose ()
-
-            and Pairwise<'T,'V> (next:Consumer<'T*'T,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                let mutable isFirst = true
-                let mutable lastValue = Unchecked.defaultof<'T>
-
-                override __.ProcessNext (input:'T) : bool = 
-                    if isFirst then
-                        lastValue <- input
-                        isFirst <- false
-                        false
-                    else
-                        let currentPair = lastValue, input
-                        lastValue <- input
-                        avoidTailCall (next.ProcessNext currentPair)
-
-            and Scan<'T,'State,'V> (folder:'State->'T->'State, initialState: 'State, next:Consumer<'State,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt folder
-                let mutable foldResult = initialState
-
-                override __.ProcessNext (input:'T) : bool =
-                    foldResult <- f.Invoke(foldResult, input)
-                    avoidTailCall (next.ProcessNext foldResult)
-
-            and Skip<'T,'V> (skipCount:int, next:Consumer<'T,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                let mutable count = 0
-
-                override __.Skipping () =
-                    if count < skipCount then
-                        count <- count + 1
-                        true
-                    else
-                        false
-
-                override __.ProcessNext (input:'T) : bool = 
-                    if count < skipCount then
-                        count <- count + 1
-                        false
-                    else
-                        avoidTailCall (next.ProcessNext input)
-
-                override __.OnComplete _ =
-                    if count < skipCount then
-                        let x = skipCount - count
-                        invalidOpFmt "tried to skip {0} {1} past the end of the seq"
-                            [|SR.GetString SR.notEnoughElements; x; (if x=1 then "element" else "elements")|]
-
-            and SkipWhile<'T,'V> (predicate:'T->bool, next:Consumer<'T,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                let mutable skip = true
-
-                override __.ProcessNext (input:'T) : bool = 
-                    if skip then
-                        skip <- predicate input
-                        if skip then
-                            false
-                        else
-                            avoidTailCall (next.ProcessNext input)
-                    else
-                        avoidTailCall (next.ProcessNext input)
-
-            and Take<'T,'V> (takeCount:int, outOfBand:IOutOfBand, next:Consumer<'T,'V>, pipelineIdx:int) =
-                inherit Truncate<'T, 'V>(takeCount, outOfBand, next, pipelineIdx)
-
-                override this.OnComplete terminatingIdx =
-                    if terminatingIdx < pipelineIdx && this.Count < takeCount then
-                        let x = takeCount - this.Count
-                        invalidOpFmt "tried to take {0} {1} past the end of the seq"
-                            [|SR.GetString SR.notEnoughElements; x; (if x=1 then "element" else "elements")|]
-
-            and TakeWhile<'T,'V> (predicate:'T->bool, outOfBand:IOutOfBand, next:Consumer<'T,'V>, pipeIdx:int) =
-                inherit SeqComponent<'T,'V>(next)
-
-                override __.ProcessNext (input:'T) : bool = 
-                    if predicate input then
-                        avoidTailCall (next.ProcessNext input)
-                    else
-                        outOfBand.StopFurtherProcessing pipeIdx
-                        false
-
-            and Tail<'T, 'V> (next:Consumer<'T,'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                let mutable first = true
-
-                override __.ProcessNext (input:'T) : bool =
-                    if first then
-                        first <- false
-                        false
-                    else
-                        avoidTailCall (next.ProcessNext input)
-
-                override this.OnComplete _ =
-                    if first then
-                        invalidArg "source" (SR.GetString(SR.notEnoughElements))
-
-            and Truncate<'T,'V> (truncateCount:int, outOfBand:IOutOfBand, next:Consumer<'T,'V>, pipeIdx:int) =
-                inherit SeqComponent<'T,'V>(next)
-
-                let mutable count = 0
-
-                member __.Count = count
-
-                override __.ProcessNext (input:'T) : bool = 
-                    if count < truncateCount then
-                        count <- count + 1
-                        if count = truncateCount then
-                            outOfBand.StopFurtherProcessing pipeIdx
-                        avoidTailCall (next.ProcessNext input)
-                    else
-                        outOfBand.StopFurtherProcessing pipeIdx
-                        false
-
-            and Windowed<'T,'V> (windowSize: int, next:Consumer<'T[],'V>) =
-                inherit SeqComponent<'T,'V>(next)
-
-                let circularBuffer = Array.zeroCreateUnchecked windowSize
-                let mutable idx = 0
-
-                let mutable priming = windowSize - 1
-
-                override __.ProcessNext (input:'T) : bool =
-                    circularBuffer.[idx] <- input
-                    
-                    idx <- idx + 1
-                    if idx = windowSize then
-                        idx <- 0
-
-                    if priming > 0 then
-                        priming <- priming - 1
-                        false
-                    else
-                        if windowSize < 32 then
-                            let window = Array.init windowSize (fun i -> circularBuffer.[(idx+i) % windowSize])
-                            avoidTailCall (next.ProcessNext window)
-                        else
-                            let window = Array.zeroCreateUnchecked windowSize 
-                            Array.Copy(circularBuffer, idx, window, 0, windowSize - idx)
-                            Array.Copy(circularBuffer, 0, window, windowSize - idx, idx)
-                            avoidTailCall (next.ProcessNext window)
-
-            type SeqProcessNextStates =
-            | InProcess  = 0
-            | NotStarted = 1
-            | Finished   = 2
-
-            type Result<'T>() =
-                let mutable haltedIdx = 0
-                
-                member val Current = Unchecked.defaultof<'T> with get, set
-                member val SeqState = SeqProcessNextStates.NotStarted with get, set
-                member __.HaltedIdx = haltedIdx
-
-                interface IOutOfBand with
-                    member __.StopFurtherProcessing pipeIdx = haltedIdx <- pipeIdx
-
-            // SetResult<> is used at the end of the chain of SeqComponents to assign the final value
-            type SetResult<'T> (result:Result<'T>) =
-                inherit Consumer<'T,'T>()
-
-                override __.ProcessNext (input:'T) : bool =
-                    result.Current <- input
-                    true
-
-            type OutOfBand() =
-                let mutable haltedIdx = 0
-                interface IOutOfBand with member __.StopFurtherProcessing pipeIdx = haltedIdx <- pipeIdx
-                member __.HaltedIdx = haltedIdx
-
-            module ForEach =
-                let enumerable (enumerable:IEnumerable<'T>) (outOfBand:OutOfBand) (consumer:Consumer<'T,'U>) =
-                    use enumerator = enumerable.GetEnumerator ()
-                    while (outOfBand.HaltedIdx = 0) && (enumerator.MoveNext ()) do
-                        consumer.ProcessNext enumerator.Current |> ignore
-
-                let array (array:array<'T>) (outOfBand:OutOfBand) (consumer:Consumer<'T,'U>) =
-                    let mutable idx = 0
-                    while (outOfBand.HaltedIdx = 0) && (idx < array.Length) do
-                        consumer.ProcessNext array.[idx] |> ignore
-                        idx <- idx + 1
-
-                let list (alist:list<'T>) (outOfBand:OutOfBand) (consumer:Consumer<'T,'U>) =
-                    let rec iterate lst =
-                        match outOfBand.HaltedIdx, lst with
-                        | 0, hd :: tl ->
-                            consumer.ProcessNext hd |> ignore
-                            iterate tl
-                        | _ -> ()
-                    iterate alist
-
-                let unfold (generator:'S->option<'T*'S>) state (outOfBand:OutOfBand) (consumer:Consumer<'T,'U>) = 
-                    let rec iterate current =
-                        match outOfBand.HaltedIdx, generator current with
-                        | 0, Some (item, next) ->
-                            consumer.ProcessNext item |> ignore
-                            iterate next
-                        | _ -> ()
-    
-                    iterate state
-
-                let makeIsSkipping (consumer:Consumer<'T,'U>) =
-                    match consumer with
-                    | :? SeqComponent<'T,'U> as c -> c.Skipping
-                    | _ -> fun () -> false
-
-                let init f (terminatingIdx:int) (outOfBand:OutOfBand) (consumer:Consumer<'T,'U>) =
-                    let mutable idx = -1
-                    let isSkipping = makeIsSkipping consumer
-                    let mutable maybeSkipping = true
-                    while (outOfBand.HaltedIdx = 0) && (idx < terminatingIdx) do
-                        if maybeSkipping then
-                            maybeSkipping <- isSkipping ()
-
-                        if (not maybeSkipping) then
-                            consumer.ProcessNext (f (idx+1)) |> ignore
-
-                        idx <- idx + 1
-
-                let execute (f:(unit->unit)->#Consumer<'U,'U>) (current:ISeqFactory<'T,'U>) executeOn =
-                    let pipeline = OutOfBand()
-                    let result = f (fun () -> (pipeline:>IOutOfBand).StopFurtherProcessing (current.PipeIdx+1))
-                    let consumer = current.Create pipeline emptyPipeIdx result
-                    try
-                        executeOn pipeline consumer
-                        (upcastICompletionChaining consumer).OnComplete pipeline.HaltedIdx
-                        result
-                    finally
-                        (upcastICompletionChaining consumer).OnDispose ()
-
-            module Enumerable =
-                type Empty<'T>() =
-                    let current () = failwith "library implementation error: Current should never be called"
-                    interface IEnumerator<'T> with
-                        member __.Current = current ()
-                    interface IEnumerator with
-                        member __.Current = current ()
-                        member __.MoveNext () = false
-                        member __.Reset (): unit = noReset ()
-                    interface IDisposable with
-                        member __.Dispose () = ()
-
-                type EmptyEnumerators<'T>() = 
-                    static let element : IEnumerator<'T> = upcast (new Empty<'T> ())
-                    static member Element = element
-
-                [<AbstractClass>]
-                type EnumeratorBase<'T>(result:Result<'T>, seqComponent:ICompletionChaining) =
-                    interface IDisposable with
-                        member __.Dispose() : unit =
-                            seqComponent.OnDispose ()
-
-                    interface IEnumerator with
-                        member this.Current : obj = box ((upcastEnumerator this)).Current
-                        member __.MoveNext () = failwith "library implementation error: derived class should implement (should be abstract)"
-                        member __.Reset () : unit = noReset ()
-
-                    interface IEnumerator<'T> with
-                        member __.Current =
-                            if result.SeqState = SeqProcessNextStates.InProcess then result.Current
-                            else
-                                match result.SeqState with
-                                | SeqProcessNextStates.NotStarted -> notStarted()
-                                | SeqProcessNextStates.Finished -> alreadyFinished()
-                                | _ -> failwith "library implementation error: all states should have been handled"
-
-                and [<AbstractClass>] EnumerableBase<'T> () =
-                    let derivedClassShouldImplement () =
-                        failwith "library implementation error: derived class should implement (should be abstract)"
-
-                    abstract member Append<'T>   : (seq<'T>) -> IEnumerable<'T>
-
-                    default this.Append source = upcastEnumerable (AppendEnumerable [this; source])
-
-                    interface IEnumerable with
-                        member this.GetEnumerator () : IEnumerator =
-                            let genericEnumerable = upcastEnumerable this
-                            let genericEnumerator = genericEnumerable.GetEnumerator ()
-                            upcastEnumeratorNonGeneric genericEnumerator
-
-                    interface IEnumerable<'T> with
-                        member this.GetEnumerator () : IEnumerator<'T> = derivedClassShouldImplement ()
-
-                    interface ISeq<'T> with
-                        member __.Compose _ = derivedClassShouldImplement ()
-                        member __.ForEach _ = derivedClassShouldImplement ()
-
-                and Enumerator<'T,'U>(source:IEnumerator<'T>, seqComponent:Consumer<'T,'U>, result:Result<'U>) =
-                    inherit EnumeratorBase<'U>(result, seqComponent)
-
-                    let rec moveNext () =
-                        if (result.HaltedIdx = 0) && source.MoveNext () then
-                            if seqComponent.ProcessNext source.Current then
-                                true
-                            else
-                                moveNext ()
-                        else
-                            result.SeqState <- SeqProcessNextStates.Finished
-                            (upcastICompletionChaining seqComponent).OnComplete result.HaltedIdx
-                            false
-
-                    interface IEnumerator with
-                        member __.MoveNext () =
-                            result.SeqState <- SeqProcessNextStates.InProcess
-                            moveNext ()
-
-                    interface IDisposable with
-                        member __.Dispose() =
-                            try
-                                source.Dispose ()
-                            finally
-                                (upcastICompletionChaining seqComponent).OnDispose ()
-
-                and Enumerable<'T,'U>(enumerable:IEnumerable<'T>, current:ISeqFactory<'T,'U>) =
-                    inherit EnumerableBase<'U>()
-
-                    interface IEnumerable<'U> with
-                        member this.GetEnumerator () : IEnumerator<'U> =
-                            let result = Result<'U> ()
-                            upcastEnumerator (new Enumerator<'T,'U>(enumerable.GetEnumerator(), current.Create result emptyPipeIdx (SetResult<'U> result), result))
-
-                    interface ISeq<'U> with
-                        member __.Compose (next:ISeqFactory<'U,'V>) : ISeq<'V> =
-                            upcastSeq (new Enumerable<'T,'V>(enumerable, ComposedFactory.Combine current next))
-
-                        member this.ForEach (f:(unit->unit)->#Consumer<'U,'U>) =
-                            ForEach.execute f current (ForEach.enumerable enumerable)
-
-                and ConcatEnumerator<'T, 'Collection when 'Collection :> seq<'T>> (sources:seq<'Collection>) =
-                    let mutable state = SeqProcessNextStates.NotStarted
-                    let main = sources.GetEnumerator ()
-
-                    let mutable active = EmptyEnumerators.Element
-
-                    let rec moveNext () =
-                        if active.MoveNext () then
-                            true
-                        elif main.MoveNext () then
-                            active.Dispose ()
-                            active <- main.Current.GetEnumerator ()
-                            moveNext ()
-                        else
-                            state <- SeqProcessNextStates.Finished
-                            false
-
-                    interface IEnumerator<'T> with
-                        member __.Current =
-                            if state = SeqProcessNextStates.InProcess then active.Current
-                            else
-                                match state with
-                                | SeqProcessNextStates.NotStarted -> notStarted()
-                                | SeqProcessNextStates.Finished -> alreadyFinished()
-                                | _ -> failwith "library implementation error: all states should have been handled"
-
-                    interface IEnumerator with
-                        member this.Current = box ((upcastEnumerator this)).Current
-                        member __.MoveNext () =
-                            state <- SeqProcessNextStates.InProcess
-                            moveNext ()
-                        member __.Reset () = noReset ()
-
-                    interface IDisposable with
-                        member __.Dispose() =
-                            main.Dispose ()
-                            active.Dispose ()
-
-                and AppendEnumerable<'T> (sources:list<seq<'T>>) =
-                    inherit EnumerableBase<'T>()
-
-                    interface IEnumerable<'T> with
-                        member this.GetEnumerator () : IEnumerator<'T> =
-                            upcastEnumerator (new ConcatEnumerator<_,_> (sources |> List.rev))
-
-                    override this.Append source =
-                        upcastEnumerable (AppendEnumerable (source :: sources))
-
-                    interface ISeq<'T> with
-                        member this.Compose (next:ISeqFactory<'T,'U>) : ISeq<'U> =
-                            upcastSeq (Enumerable<'T,'V>(this, next))
-
-                        member this.ForEach (f:(unit->unit)->#Consumer<'T,'T>) =
-                            ForEach.execute f IdentityFactory.Instance (ForEach.enumerable this)
-
-                and ConcatEnumerable<'T, 'Collection when 'Collection :> seq<'T>> (sources:seq<'Collection>) =
-                    inherit EnumerableBase<'T>()
-
-                    interface IEnumerable<'T> with
-                        member this.GetEnumerator () : IEnumerator<'T> =
-                            upcastEnumerator (new ConcatEnumerator<_,_> (sources))
-
-                    interface ISeq<'T> with
-                        member this.Compose (next:ISeqFactory<'T,'U>) : ISeq<'U> =
-                            upcastSeq (Enumerable<'T,'V>(this, next))
-
-                        member this.ForEach (f:(unit->unit)->#Consumer<'T,'T>) =
-                            ForEach.execute f IdentityFactory.Instance (ForEach.enumerable this)
-
-                let create enumerable current =
-                    upcastSeq (Enumerable(enumerable, current))
-
-            module EmptyEnumerable =
-                type Enumerable<'T> () =
-                    inherit Enumerable.EnumerableBase<'T>()
-
-                    static let singleton = Enumerable<'T>() :> ISeq<'T>
-                    static member Instance = singleton
-
-                    interface IEnumerable<'T> with
-                        member this.GetEnumerator () : IEnumerator<'T> = IEnumerator.Empty<'T>()
-
-                    override this.Append source =
-                        upcastEnumerable (Enumerable.Enumerable<'T,'T> (source, IdentityFactory.Instance))
-
-                    interface ISeq<'T> with
-                        member this.Compose (next:ISeqFactory<'T,'U>) : ISeq<'U> =
-                            upcastSeq (Enumerable.Enumerable<'T,'V>(this, next))
-
-                        member this.ForEach (f:(unit->unit)->#Consumer<'T,'T>) =
-                            ForEach.execute f IdentityFactory.Instance (ForEach.enumerable this)
-
-
-
-            module Array =
-                type Enumerator<'T,'U>(delayedArray:unit->array<'T>, seqComponent:Consumer<'T,'U>, result:Result<'U>) =
-                    inherit Enumerable.EnumeratorBase<'U>(result, seqComponent)
-
-                    let mutable idx = 0
-                    let mutable array = Unchecked.defaultof<_>
-
-                    let mutable initMoveNext = Unchecked.defaultof<_>
-                    do
-                        initMoveNext <-
-                            fun () ->
-                                result.SeqState <- SeqProcessNextStates.InProcess
-                                array <- delayedArray ()
-                                initMoveNext <- ignore
-
-                    let rec moveNext () =
-                        if (result.HaltedIdx = 0) && idx < array.Length then
-                            idx <- idx+1
-                            if seqComponent.ProcessNext array.[idx-1] then
-                                true
-                            else
-                                moveNext ()
-                        else
-                            result.SeqState <- SeqProcessNextStates.Finished
-                            (upcastICompletionChaining seqComponent).OnComplete result.HaltedIdx
-                            false
-
-                    interface IEnumerator with
-                        member __.MoveNext () =
-                            initMoveNext ()
-                            moveNext ()
-
-                type Enumerable<'T,'U>(delayedArray:unit->array<'T>, current:ISeqFactory<'T,'U>) =
-                    inherit Enumerable.EnumerableBase<'U>()
-
-                    interface IEnumerable<'U> with
-                        member this.GetEnumerator () : IEnumerator<'U> =
-                            let result = Result<'U> ()
-                            upcastEnumerator (new Enumerator<'T,'U>(delayedArray, current.Create result emptyPipeIdx (SetResult<'U> result), result))
-
-                    interface ISeq<'U> with
-                        member __.Compose (next:ISeqFactory<'U,'V>) : ISeq<'V> =
-                            upcastSeq (new Enumerable<'T,'V>(delayedArray, ComposedFactory.Combine current next))
-
-                        member this.ForEach (f:(unit->unit)->#Consumer<'U,'U>) =
-                            ForEach.execute f current (ForEach.array (delayedArray ()))
-
-                let createDelayed (delayedArray:unit->array<'T>) (current:ISeqFactory<'T,'U>) =
-                    upcastSeq (Enumerable(delayedArray, current))
-
-                let create (array:array<'T>) (current:ISeqFactory<'T,'U>) =
-                    createDelayed (fun () -> array) current
-
-                let createDelayedId (delayedArray:unit -> array<'T>) =
-                    createDelayed delayedArray IdentityFactory.Instance
-
-                let createId (array:array<'T>) =
-                    create array IdentityFactory.Instance
-
-            module List =
-                type Enumerator<'T,'U>(alist:list<'T>, seqComponent:Consumer<'T,'U>, result:Result<'U>) =
-                    inherit Enumerable.EnumeratorBase<'U>(result, seqComponent)
-
-                    let mutable list = alist
-
-                    let rec moveNext current =
-                        match result.HaltedIdx, current with
-                        | 0, head::tail -> 
-                            if seqComponent.ProcessNext head then
-                                list <- tail
-                                true
-                            else
-                                moveNext tail
-                        | _ ->
-                            result.SeqState <- SeqProcessNextStates.Finished
-                            (upcastICompletionChaining seqComponent).OnComplete result.HaltedIdx
-                            false
-
-                    interface IEnumerator with
-                        member __.MoveNext () =
-                            result.SeqState <- SeqProcessNextStates.InProcess
-                            moveNext list
-
-                type Enumerable<'T,'U>(alist:list<'T>, current:ISeqFactory<'T,'U>) =
-                    inherit Enumerable.EnumerableBase<'U>()
-
-                    interface IEnumerable<'U> with
-                        member this.GetEnumerator () : IEnumerator<'U> =
-                            let result = Result<'U> ()
-                            upcastEnumerator (new Enumerator<'T,'U>(alist, current.Create result emptyPipeIdx (SetResult<'U> result), result))
-
-                    interface ISeq<'U> with
-                        member __.Compose (next:ISeqFactory<'U,'V>) : ISeq<'V> =
-                            upcastSeq (new Enumerable<'T,'V>(alist, ComposedFactory.Combine current next))
-
-                        member this.ForEach (f:(unit->unit)->#Consumer<'U,'U>) =
-                            ForEach.execute f current (ForEach.list alist)
-
-                let create alist current =
-                    upcastSeq (Enumerable(alist, current))
-
-            module Unfold =
-                type Enumerator<'T,'U,'State>(generator:'State->option<'T*'State>, state:'State, seqComponent:Consumer<'T,'U>, result:Result<'U>) =
-                    inherit Enumerable.EnumeratorBase<'U>(result, seqComponent)
-
-                    let mutable current = state
-
-                    let rec moveNext () =
-                        match result.HaltedIdx, generator current with
-                        | 0, Some (item, nextState) ->
-                            current <- nextState
-                            if seqComponent.ProcessNext item then
-                                true
-                            else
-                                moveNext ()
-                        | _ -> false
-
-                    interface IEnumerator with
-                        member __.MoveNext () =
-                            result.SeqState <- SeqProcessNextStates.InProcess
-                            moveNext ()
-
-                type Enumerable<'T,'U,'GeneratorState>(generator:'GeneratorState->option<'T*'GeneratorState>, state:'GeneratorState, current:ISeqFactory<'T,'U>) =
-                    inherit Enumerable.EnumerableBase<'U>()
-
-                    interface IEnumerable<'U> with
-                        member this.GetEnumerator () : IEnumerator<'U> =
-                            let result = Result<'U> ()
-                            upcastEnumerator (new Enumerator<'T,'U,'GeneratorState>(generator, state, current.Create result emptyPipeIdx (SetResult<'U> result), result))
-
-                    interface ISeq<'U> with
-                        member this.Compose (next:ISeqFactory<'U,'V>) : ISeq<'V> =
-                            upcastSeq (new Enumerable<'T,'V,'GeneratorState>(generator, state, ComposedFactory.Combine current next))
-
-                        member this.ForEach (f:(unit->unit)->#Consumer<'U,'U>) =
-                            ForEach.execute f current (ForEach.unfold generator state)
-
-            module Init =
-                // The original implementation of "init" delayed the calculation of Current, and so it was possible
-                // to do MoveNext without it's value being calculated.
-                // I can imagine only two scenerios where that is possibly sane, although a simple solution is readily
-                // at hand in both cases. The first is that of an expensive generator function, where you skip the
-                // first n elements. The simple solution would have just been to have a map ((+) n) as the first operation
-                // instead. The second case would be counting elements, but that is only of use if you're not filtering
-                // or mapping or doing anything else (as that would cause Current to be evaluated!) and
-                // so you already know what the count is!! Anyway, someone thought it was a good idea, so
-                // I have had to add an extra function that is used in Skip to determine if we are touching
-                // Current or not.
-
-                let getTerminatingIdx (count:Nullable<int>) =
-                    // we are offset by 1 to allow for values going up to System.Int32.MaxValue
-                    // System.Int32.MaxValue is an illegal value for the "infinite" sequence
-                    if count.HasValue then
-                        count.Value - 1
-                    else
-                        System.Int32.MaxValue
-
-                type Enumerator<'T,'U>(count:Nullable<int>, f:int->'T, seqComponent:Consumer<'T,'U>, result:Result<'U>) =
-                    inherit Enumerable.EnumeratorBase<'U>(result, seqComponent)
-
-                    let isSkipping =
-                        ForEach.makeIsSkipping seqComponent
-
-                    let terminatingIdx =
-                        getTerminatingIdx count
-
-                    let mutable maybeSkipping = true
-                    let mutable idx = -1
-
-                    let rec moveNext () =
-                        if (result.HaltedIdx = 0) && idx < terminatingIdx then
-                            idx <- idx + 1
-
-                            if maybeSkipping then
-                                // Skip can only is only checked at the start of the sequence, so once
-                                // triggered, we stay triggered.
-                                maybeSkipping <- isSkipping ()
-                    
-                            if maybeSkipping then
-                                moveNext ()
-                            elif seqComponent.ProcessNext (f idx) then
-                                true
-                            else
-                                moveNext ()
-                        elif (result.HaltedIdx = 0) && idx = System.Int32.MaxValue then
-                            raise <| System.InvalidOperationException (SR.GetString(SR.enumerationPastIntMaxValue))
-                        else
-                            result.SeqState <- SeqProcessNextStates.Finished
-                            (upcastICompletionChaining seqComponent).OnComplete result.HaltedIdx
-                            false
-
-                    interface IEnumerator with
-                        member __.MoveNext () =
-                            result.SeqState <- SeqProcessNextStates.InProcess
-                            moveNext ()
-
-                type Enumerable<'T,'U>(count:Nullable<int>, f:int->'T, current:ISeqFactory<'T,'U>) =
-                    inherit Enumerable.EnumerableBase<'U>()
-
-                    interface IEnumerable<'U> with
-                        member this.GetEnumerator () : IEnumerator<'U> =
-                            let result = Result<'U> ()
-                            upcastEnumerator (new Enumerator<'T,'U>(count, f, current.Create result emptyPipeIdx (SetResult<'U> result), result))
-
-                    interface ISeq<'U> with
-                        member this.Compose (next:ISeqFactory<'U,'V>) : ISeq<'V> =
-                            upcastSeq (new Enumerable<'T,'V>(count, f, ComposedFactory.Combine current next))
-
-                        member this.ForEach (createResult:(unit->unit)->#Consumer<'U,'U>) =
-                            let terminatingIdx = getTerminatingIdx count
-                            ForEach.execute createResult current (ForEach.init f terminatingIdx)
-
-                let upto lastOption f =
-                    match lastOption with
-                    | Some b when b<0 -> failwith "library implementation error: upto can never be called with a negative value"
-                    | _ ->
-                        let unstarted   = -1  // index value means unstarted (and no valid index)
-                        let completed   = -2  // index value means completed (and no valid index)
-                        let unreachable = -3  // index is unreachable from 0,1,2,3,...
-                        let finalIndex  = match lastOption with
-                                          | Some b -> b             // here b>=0, a valid end value.
-                                          | None   -> unreachable   // run "forever", well as far as Int32.MaxValue since indexing with a bounded type.
-                        // The Current value for a valid index is "f i".
-                        // Lazy<_> values are used as caches, to store either the result or an exception if thrown.
-                        // These "Lazy<_>" caches are created only on the first call to current and forced immediately.
-                        // The lazy creation of the cache nodes means enumerations that skip many Current values are not delayed by GC.
-                        // For example, the full enumeration of Seq.initInfinite in the tests.
-                        // state
-                        let index   = ref unstarted
-                        // a Lazy node to cache the result/exception
-                        let current = ref (Unchecked.defaultof<_>)
-                        let setIndex i = index := i; current := (Unchecked.defaultof<_>) // cache node unprimed, initialised on demand.
-                        let getCurrent() =
-                            if !index = unstarted then notStarted()
-                            if !index = completed then alreadyFinished()
-                            match box !current with
-                            | null -> current := Lazy<_>.Create(fun () -> f !index)
-                            | _ ->  ()
-                            // forced or re-forced immediately.
-                            (!current).Force()
-                        { new IEnumerator<'U> with
-                              member x.Current = getCurrent()
-                          interface IEnumerator with
-                              member x.Current = box (getCurrent())
-                              member x.MoveNext() =
-                                  if !index = completed then
-                                      false
-                                  elif !index = unstarted then
-                                      setIndex 0
-                                      true
-                                  else (
-                                      if !index = System.Int32.MaxValue then raise <| System.InvalidOperationException (SR.GetString(SR.enumerationPastIntMaxValue))
-                                      if !index = finalIndex then
-                                          false
-                                      else
-                                          setIndex (!index + 1)
-                                          true
-                                  )
-                              member self.Reset() = noReset()
-                          interface System.IDisposable with
-                              member x.Dispose() = () }
-
-                type EnumerableDecider<'T>(count:Nullable<int>, f:int->'T) =
-                    inherit Enumerable.EnumerableBase<'T>()
-
-                    interface IEnumerable<'T> with
-                        member this.GetEnumerator () : IEnumerator<'T> =
-                            // we defer back to the original implementation as, as it's quite idiomatic in it's decision
-                            // to calculate Current in a lazy fashion. I doubt anyone is really using this functionality
-                            // in the way presented, but it's possible.
-                            upto (if count.HasValue then Some (count.Value-1) else None) f
-
-                    interface ISeq<'T> with
-                        member this.Compose (next:ISeqFactory<'T,'U>) : ISeq<'U> =
-                            upcastSeq (Enumerable<'T,'V>(count, f, next))
-
-                        member this.ForEach (f:(unit->unit)->#Consumer<'T,'T>) =
-                            ForEach.execute f IdentityFactory.Instance (ForEach.enumerable (upcastEnumerable this))
-
-            open RuntimeHelpers
-
-            [<CompiledName("ToComposer")>]
-            let toComposer (source:seq<'T>) : ISeq<'T> = 
-                checkNonNull "source" source
-                match source with
-                | :? ISeq<'T> as s -> s
-                | :? array<'T> as a -> upcastSeq (Array.Enumerable((fun () -> a), IdentityFactory.Instance))
-                | :? list<'T> as a -> upcastSeq (List.Enumerable(a, IdentityFactory.Instance))
-                | _ -> upcastSeq (Enumerable.Enumerable<'T,'T>(source, IdentityFactory.Instance))
-
-            let inline foreach f (source:ISeq<_>) =
-                source.ForEach f
-
-            let inline compose factory (source:ISeq<'T>) =
-                source.Compose factory
-
-            [<CompiledName("Empty")>]
-            let empty<'T> = EmptyEnumerable.Enumerable<'T>.Instance
-
-            [<CompiledName("Unfold")>]
-            let unfold (generator:'State->option<'T * 'State>) (state:'State) : ISeq<'T> =
-                upcastSeq (new Unfold.Enumerable<'T,'T,'State>(generator, state, IdentityFactory.Instance))
-
-            [<CompiledName("InitializeInfinite")>]
-            let initInfinite<'T> (f:int->'T) : ISeq<'T> =
-                upcastSeq (new Init.EnumerableDecider<'T>(Nullable (), f))
-
-            [<CompiledName("Initialize")>]
-            let init<'T> (count:int) (f:int->'T) : ISeq<'T> =
-                if count < 0 then invalidArgInputMustBeNonNegative "count" count
-                elif count = 0 then empty else
-                upcastSeq (new Init.EnumerableDecider<'T>(Nullable count, f))
-
-            [<CompiledName("Iterate")>]
-            let iter f (source:ISeq<'T>) =
-                source
-                |> foreach (fun _ ->
-                    { new Consumer<'T,'T> () with
-                        override this.ProcessNext value =
-                            f value
-                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
-                |> ignore
-
-            [<CompiledName("TryItem")>]
-            let tryItem i (source:ISeq<'T>) =
-                if i < 0 then None else
-                source 
-                |> foreach (fun halt ->
-                    { new Folder<'T, Values<int, Option<'T>>> (Values<_,_> (0, None)) with
-                        override this.ProcessNext value =
-                            if this.Value._1 = i then
-                                this.Value._2 <- Some value
-                                halt ()
-                            else
-                                this.Value._1 <- this.Value._1 + 1
-                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
-                |> fun item -> item.Value._2
-
-            [<CompiledName("IterateIndexed")>]
-            let iteri f (source:ISeq<'T>) =
-                let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt f
-
-                source
-                |> foreach (fun _ ->
-                    { new Folder<'T, int> (0) with
-                        override this.ProcessNext value =
-                            f.Invoke(this.Value, value)
-                            this.Value <- this.Value + 1
-                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
-                |> ignore
-
-            [<CompiledName("Exists")>]
-            let exists f (source:ISeq<'T>) =
-                source
-                |> foreach (fun halt ->
-                    { new Folder<'T, bool> (false) with
-                        override this.ProcessNext value =
-                            if f value then
-                                this.Value <- true
-                                halt ()
-                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
-                |> fun exists -> exists.Value
-
-            [<CompiledName("Contains")>]
-            let inline contains element (source:ISeq<'T>) =
-                source
-                |> foreach (fun halt ->
-                    { new Folder<'T, bool> (false) with
-                        override this.ProcessNext value =
-                            if element = value then
-                                this.Value <- true
-                                halt ()
-                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
-                |> fun contains -> contains.Value
-
-            [<CompiledName("ForAll")>]
-            let forall f (source:ISeq<'T>) =
-                source
-                |> foreach (fun halt ->
-                    { new Folder<'T, bool> (true) with
-                        override this.ProcessNext value =
-                            if not (f value) then
-                                this.Value <- false
-                                halt ()
-                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
-                |> fun forall -> forall.Value
-
-            [<CompiledName("Filter")>]
-            let filter<'T> (f:'T->bool) (source:ISeq<'T>) : ISeq<'T> =
-                source
-                |> compose (FilterFactory f)
-
-            [<CompiledName("Map")>]
-            let map<'T,'U> (f:'T->'U) (source:ISeq<'T>) : ISeq<'U> =
-                source
-                |> compose (MapFactory f)
-
-            [<CompiledName("MapIndexed")>]
-            let mapi f source =
-                source
-                |> compose (MapiFactory f)
-
-            [<CompiledName("Choose")>]
-            let choose f source =
-                source
-                |> compose (ChooseFactory f)
-
-            [<CompiledName("Indexed")>]
-            let indexed source =
-                source
-                |> compose (MapiFactory (fun i x -> i,x))
-
-            [<CompiledName("TryPick")>]
-            let tryPick f (source:ISeq<'T>)  =
-                source
-                |> foreach (fun halt ->
-                    { new Folder<'T, Option<'U>> (None) with
-                        override this.ProcessNext value =
-                            match f value with
-                            | (Some _) as some ->
-                                this.Value <- some
-                                halt ()
-                            | None -> ()
-                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
-                |> fun pick -> pick.Value
-
-            [<CompiledName("TryFind")>]
-            let tryFind f (source:ISeq<'T>)  =
-                source 
-                |> foreach (fun halt ->
-                    { new Folder<'T, Option<'T>> (None) with
-                        override this.ProcessNext value =
-                            if f value then
-                                this.Value <- Some value
-                                halt ()
-                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
-                |> fun find -> find.Value
-
-
 #if FX_NO_ICLONEABLE
         open Microsoft.FSharp.Core.ICloneableExtensions
 #else
 #endif
 
-        open Microsoft.FSharp.Core.CompilerServices.RuntimeHelpers
-
         let mkDelayedSeq (f: unit -> IEnumerable<'T>) = mkSeq (fun () -> f().GetEnumerator())
         let inline indexNotFound() = raise (new System.Collections.Generic.KeyNotFoundException(SR.GetString(SR.keyNotFoundAlt)))
         
         [<CompiledName("ToComposer")>]
-        let toComposer (source:seq<'T>): Composer.Internal.ISeq<'T> = 
-            Composer.toComposer source
+        let toComposer (source:seq<'T>): Composer.Core.ISeq<'T> = 
+            Composer.Seq.toComposer source
         
         let inline foreach f (source:seq<_>) =
-            Composer.foreach f (toComposer source)
+            Composer.Seq.foreach f (toComposer source)
 
         [<CompiledName("Delay")>]
         let delay f = mkDelayedSeq f
 
         [<CompiledName("Unfold")>]
         let unfold (generator:'State->option<'T * 'State>) (state:'State) : seq<'T> =
-            Composer.unfold generator state
+            Composer.Seq.unfold generator state
             |> Composer.Helpers.upcastEnumerable
 
         [<CompiledName("Empty")>]
@@ -1735,24 +58,24 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("InitializeInfinite")>]
         let initInfinite<'T> (f:int->'T) : IEnumerable<'T> =
-            Composer.initInfinite f
+            Composer.Seq.initInfinite f
             |> Composer.Helpers.upcastEnumerable
 
         [<CompiledName("Initialize")>]
         let init<'T> (count:int) (f:int->'T) : IEnumerable<'T> =
-            Composer.init count f
+            Composer.Seq.init count f
             |> Composer.Helpers.upcastEnumerable
 
         [<CompiledName("Iterate")>]
         let iter f (source : seq<'T>) =
-            Composer.iter f (toComposer source)
+            Composer.Seq.iter f (toComposer source)
 
         [<CompiledName("Item")>]
         let item i (source : seq<'T>) =
             if i < 0 then invalidArgInputMustBeNonNegative "index" i else
                 source 
                 |> foreach (fun halt ->
-                    { new Composer.Internal.Folder<'T, Composer.Internal.Values<int, bool, 'T>> (Composer.Internal.Values<_,_,_> (0, false, Unchecked.defaultof<'T>)) with
+                    { new Composer.Core.Folder<'T, Composer.Core.Values<int, bool, 'T>> (Composer.Core.Values<_,_,_> (0, false, Unchecked.defaultof<'T>)) with
                         override this.ProcessNext value =
                             if this.Value._1 = i then
                                 this.Value._2 <- true
@@ -1772,26 +95,26 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("TryItem")>]
         let tryItem i (source:seq<'T>) =
-            Composer.tryItem i (toComposer source)
+            Composer.Seq.tryItem i (toComposer source)
 
         [<CompiledName("Get")>]
         let nth i (source : seq<'T>) = item i source
 
         [<CompiledName("IterateIndexed")>]
         let iteri f (source:seq<'T>) =
-            Composer.iteri f (toComposer source)
+            Composer.Seq.iteri f (toComposer source)
 
         [<CompiledName("Exists")>]
         let exists f (source:seq<'T>) =
-            Composer.exists f (toComposer source)
+            Composer.Seq.exists f (toComposer source)
 
         [<CompiledName("Contains")>]
         let inline contains element (source:seq<'T>) =
-            Composer.contains element (toComposer source)
+            Composer.Seq.contains element (toComposer source)
 
         [<CompiledName("ForAll")>]
         let forall f (source:seq<'T>) =
-            Composer.forall f (toComposer source)
+            Composer.Seq.forall f (toComposer source)
 
         [<CompiledName("Iterate2")>]
         let iter2 f (source1 : seq<_>) (source2 : seq<_>)    =
@@ -1802,7 +125,7 @@ namespace Microsoft.FSharp.Collections
 
             source1
             |> foreach (fun halt ->
-                { new Composer.Internal.Folder<_,_> () with
+                { new Composer.Core.Folder<_,_> () with
                     override this.ProcessNext value =
                         if (e2.MoveNext()) then
                             f.Invoke(value, e2.Current)
@@ -1820,7 +143,7 @@ namespace Microsoft.FSharp.Collections
 
             source1
             |> foreach (fun halt ->
-                { new Composer.Internal.Folder<_,int> (0) with
+                { new Composer.Core.Folder<_,int> (0) with
                     override this.ProcessNext value =
                         if (e2.MoveNext()) then
                             f.Invoke(this.Value, value, e2.Current)
@@ -1840,14 +163,14 @@ namespace Microsoft.FSharp.Collections
         let private seqFactory createSeqComponent (source:seq<'T>) =
             checkNonNull "source" source
             match source with
-            | :? Composer.Internal.ISeq<'T> as s -> Composer.Helpers.upcastEnumerable (s.Compose createSeqComponent)
-            | :? array<'T> as a -> Composer.Helpers.upcastEnumerable (Composer.Array.create a createSeqComponent)
-            | :? list<'T> as a -> Composer.Helpers.upcastEnumerable (Composer.List.create a createSeqComponent)
-            | _ -> Composer.Helpers.upcastEnumerable (Composer.Enumerable.create source createSeqComponent)
+            | :? Composer.Core.ISeq<'T> as s -> Composer.Helpers.upcastEnumerable (s.Compose createSeqComponent)
+            | :? array<'T> as a -> Composer.Helpers.upcastEnumerable (Composer.Seq.Array.create a createSeqComponent)
+            | :? list<'T> as a -> Composer.Helpers.upcastEnumerable (Composer.Seq.List.create a createSeqComponent)
+            | _ -> Composer.Helpers.upcastEnumerable (Composer.Seq.Enumerable.create source createSeqComponent)
 
         [<CompiledName("Filter")>]
         let filter<'T> (f:'T->bool) (source:seq<'T>) : seq<'T> =
-            Composer.filter f (toComposer source)
+            Composer.Seq.filter f (toComposer source)
             |> Composer.Helpers.upcastEnumerable
 
         [<CompiledName("Where")>]
@@ -1855,40 +178,40 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("Map")>]
         let map<'T,'U> (f:'T->'U) (source:seq<'T>) : seq<'U> =
-            Composer.map f (toComposer source)
+            Composer.Seq.map f (toComposer source)
             |> Composer.Helpers.upcastEnumerable
 
         [<CompiledName("MapIndexed")>]
         let mapi f source      =
-            Composer.mapi f (toComposer source)
+            Composer.Seq.mapi f (toComposer source)
             |> Composer.Helpers.upcastEnumerable
 
         [<CompiledName("MapIndexed2")>]
         let mapi2 f source1 source2 =
             checkNonNull "source2" source2
-            source1 |> seqFactory (Composer.Mapi2Factory (f, source2))
+            source1 |> seqFactory (Composer.Seq.Mapi2Factory (f, source2))
 
         [<CompiledName("Map2")>]
         let map2<'T,'U,'V> (f:'T->'U->'V) (source1:seq<'T>) (source2:seq<'U>) : seq<'V> =
             checkNonNull "source1" source1
             match source1 with
-            | :? Composer.Internal.ISeq<'T> as s -> Composer.Helpers.upcastEnumerable (s.Compose (Composer.Map2FirstFactory (f, source2)))
-            | _ -> source2 |> seqFactory (Composer.Map2SecondFactory (f, source1))
+            | :? Composer.Core.ISeq<'T> as s -> Composer.Helpers.upcastEnumerable (s.Compose (Composer.Seq.Map2FirstFactory (f, source2)))
+            | _ -> source2 |> seqFactory (Composer.Seq.Map2SecondFactory (f, source1))
 
         [<CompiledName("Map3")>]
         let map3 f source1 source2 source3 =
             checkNonNull "source2" source2
             checkNonNull "source3" source3
-            source1 |> seqFactory (Composer.Map3Factory (f, source2, source3))
+            source1 |> seqFactory (Composer.Seq.Map3Factory (f, source2, source3))
 
         [<CompiledName("Choose")>]
         let choose f source =
-            Composer.choose f (toComposer source)
+            Composer.Seq.choose f (toComposer source)
             |> Composer.Helpers.upcastEnumerable
 
         [<CompiledName("Indexed")>]
         let indexed source =
-            Composer.indexed (toComposer source)
+            Composer.Seq.indexed (toComposer source)
             |> Composer.Helpers.upcastEnumerable
 
         [<CompiledName("Zip")>]
@@ -1906,7 +229,7 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("TryPick")>]
         let tryPick f (source : seq<'T>)  =
-            Composer.tryPick f (toComposer source)
+            Composer.Seq.tryPick f (toComposer source)
 
         [<CompiledName("Pick")>]
         let pick f source  =
@@ -1916,7 +239,7 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("TryFind")>]
         let tryFind f (source : seq<'T>)  =
-            Composer.tryFind f (toComposer source)
+            Composer.Seq.tryFind f (toComposer source)
 
         [<CompiledName("Find")>]
         let find f source =
@@ -1929,7 +252,7 @@ namespace Microsoft.FSharp.Collections
             if count < 0 then invalidArgInputMustBeNonNegative "count" count
             (* Note: don't create or dispose any IEnumerable if n = 0 *)
             if count = 0 then empty else
-            source |> seqFactory (Composer.TakeFactory count)
+            source |> seqFactory (Composer.Seq.TakeFactory count)
 
         [<CompiledName("IsEmpty")>]
         let isEmpty (source : seq<'T>)  =
@@ -1945,7 +268,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Concat")>]
         let concat (sources:seq<#seq<'T>>) : seq<'T> =
             checkNonNull "sources" sources
-            upcast Composer.Enumerable.ConcatEnumerable sources
+            upcast Composer.Seq.Enumerable.ConcatEnumerable sources
 
         [<CompiledName("Length")>]
         let length (source : seq<'T>)    =
@@ -1967,7 +290,7 @@ namespace Microsoft.FSharp.Collections
 
             source
             |> foreach (fun _ ->
-                { new Composer.Internal.Folder<'T,'State> (x) with
+                { new Composer.Core.Folder<'T,'State> (x) with
                     override this.ProcessNext value =
                         this.Value <- f.Invoke (this.Value, value)
                         Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
@@ -1982,7 +305,7 @@ namespace Microsoft.FSharp.Collections
 
             source1
             |> foreach (fun halt ->
-                { new Composer.Internal.Folder<_,'State> (state) with
+                { new Composer.Core.Folder<_,'State> (state) with
                     override this.ProcessNext value =
                         if (e2.MoveNext()) then
                             this.Value <- f.Invoke(this.Value, value, e2.Current)
@@ -1997,7 +320,7 @@ namespace Microsoft.FSharp.Collections
 
             source
             |> foreach (fun _ ->
-                { new Composer.Internal.Folder<'T, Composer.Internal.Values<bool,'T>> (Composer.Internal.Values<_,_>(true, Unchecked.defaultof<'T>)) with
+                { new Composer.Core.Folder<'T, Composer.Core.Values<bool,'T>> (Composer.Core.Values<_,_>(true, Unchecked.defaultof<'T>)) with
                     override this.ProcessNext value =
                         if this.Value._1 then
                             this.Value._1 <- false
@@ -2027,8 +350,8 @@ namespace Microsoft.FSharp.Collections
             checkNonNull "source1" source1
             checkNonNull "source2" source2
             match source1 with
-            | :? Composer.Enumerable.EnumerableBase<'T> as s -> s.Append source2
-            | _ -> Composer.Helpers.upcastEnumerable (new Composer.Enumerable.AppendEnumerable<_>([source2; source1]))
+            | :? Composer.Seq.Enumerable.EnumerableBase<'T> as s -> s.Append source2
+            | _ -> Composer.Helpers.upcastEnumerable (new Composer.Seq.Enumerable.AppendEnumerable<_>([source2; source1]))
 
 
         [<CompiledName("Collect")>]
@@ -2043,7 +366,7 @@ namespace Microsoft.FSharp.Collections
 
             source1
             |> foreach (fun halt ->
-                { new Composer.Internal.Folder<'T,int> (0) with
+                { new Composer.Core.Folder<'T,int> (0) with
                     override this.ProcessNext value =
                         if not (e2.MoveNext()) then
                             this.Value <- 1
@@ -2072,7 +395,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("OfArray")>]
         let ofArray (source : 'T array) =
             checkNonNull "source" source
-            Composer.Helpers.upcastEnumerable (Composer.Array.createId source)
+            Composer.Helpers.upcastEnumerable (Composer.Seq.Array.createId source)
 
         [<CompiledName("ToArray")>]
         let toArray (source : seq<'T>)  =
@@ -2126,17 +449,17 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Truncate")>]
         let truncate n (source: seq<'T>) =
             if n <= 0 then empty else
-            source |> seqFactory (Composer.TruncateFactory n)
+            source |> seqFactory (Composer.Seq.TruncateFactory n)
 
         [<CompiledName("Pairwise")>]
         let pairwise<'T> (source:seq<'T>) : seq<'T*'T> =
-            source |> seqFactory (Composer.PairwiseFactory ())
+            source |> seqFactory (Composer.Seq.PairwiseFactory ())
 
         [<CompiledName("Scan")>]
         let scan<'T,'State> f (z:'State) (source : seq<'T>): seq<'State> =
             let first = [|z|] :> IEnumerable<'State>
-            let rest = source |> seqFactory (Composer.ScanFactory (f, z))
-            upcast Composer.Enumerable.ConcatEnumerable [|first; rest;|]
+            let rest = source |> seqFactory (Composer.Seq.ScanFactory (f, z))
+            upcast Composer.Seq.Enumerable.ConcatEnumerable [|first; rest;|]
 
         [<CompiledName("TryFindBack")>]
         let tryFindBack f (source : seq<'T>) =
@@ -2160,7 +483,7 @@ namespace Microsoft.FSharp.Collections
         let tryFindIndex p (source:seq<_>) =
             source
             |> foreach (fun halt ->
-                { new Composer.Internal.Folder<'T, Composer.Internal.Values<Option<int>, int>> (Composer.Internal.Values<_,_>(None, 0)) with
+                { new Composer.Core.Folder<'T, Composer.Core.Values<Option<int>, int>> (Composer.Core.Values<_,_>(None, 0)) with
                     override this.ProcessNext value =
                         if p value then
                             this.Value._1 <- Some(this.Value._2)
@@ -2191,7 +514,7 @@ namespace Microsoft.FSharp.Collections
         let windowed windowSize (source: seq<_>) =
             if windowSize <= 0 then invalidArgFmt "windowSize" "{0}\nwindowSize = {1}"
                                         [|SR.GetString SR.inputMustBePositive; windowSize|]
-            source |> seqFactory (Composer.WindowedFactory (windowSize))            
+            source |> seqFactory (Composer.Seq.WindowedFactory (windowSize))            
 
         [<CompiledName("Cache")>]
         let cache (source : seq<'T>) =
@@ -2295,7 +618,7 @@ namespace Microsoft.FSharp.Collections
         let groupByValueType (keyf:'T->'Key) (seq:seq<'T>) = seq |> groupByImpl HashIdentity.Structural<'Key> keyf id
 
         // Wrap a StructBox around all keys in case the key type is itself a type using null as a representation
-        let groupByRefType   (keyf:'T->'Key) (seq:seq<'T>) = seq |> groupByImpl StructBox<'Key>.Comparer (fun t -> StructBox (keyf t)) (fun sb -> sb.Value)
+        let groupByRefType   (keyf:'T->'Key) (seq:seq<'T>) = seq |> groupByImpl RuntimeHelpers.StructBox<'Key>.Comparer (fun t -> RuntimeHelpers.StructBox (keyf t)) (fun sb -> sb.Value)
 
         [<CompiledName("GroupBy")>]
         let groupBy (keyf:'T->'Key) (seq:seq<'T>) =
@@ -2309,11 +632,11 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("Distinct")>]
         let distinct source =
-            source |> seqFactory (Composer.DistinctFactory ())
+            source |> seqFactory (Composer.Seq.DistinctFactory ())
 
         [<CompiledName("DistinctBy")>]
         let distinctBy keyf source =
-            source |> seqFactory (Composer.DistinctByFactory keyf)
+            source |> seqFactory (Composer.Seq.DistinctByFactory keyf)
 
         [<CompiledName("SortBy")>]
         let sortBy keyf source =
@@ -2322,7 +645,7 @@ namespace Microsoft.FSharp.Collections
                 let array = source |> toArray
                 Array.stableSortInPlaceBy keyf array
                 array
-            Composer.Helpers.upcastEnumerable (Composer.Array.createDelayedId delayedSort)
+            Composer.Helpers.upcastEnumerable (Composer.Seq.Array.createDelayedId delayedSort)
 
         [<CompiledName("Sort")>]
         let sort source =
@@ -2331,7 +654,7 @@ namespace Microsoft.FSharp.Collections
                 let array = source |> toArray
                 Array.stableSortInPlace array
                 array
-            Composer.Helpers.upcastEnumerable (Composer.Array.createDelayedId delayedSort)
+            Composer.Helpers.upcastEnumerable (Composer.Seq.Array.createDelayedId delayedSort)
 
         [<CompiledName("SortWith")>]
         let sortWith f source =
@@ -2340,7 +663,7 @@ namespace Microsoft.FSharp.Collections
                 let array = source |> toArray
                 Array.stableSortInPlaceWith f array
                 array
-            Composer.Helpers.upcastEnumerable (Composer.Array.createDelayedId delayedSort)
+            Composer.Helpers.upcastEnumerable (Composer.Seq.Array.createDelayedId delayedSort)
 
         [<CompiledName("SortByDescending")>]
         let inline sortByDescending keyf source =
@@ -2373,7 +696,7 @@ namespace Microsoft.FSharp.Collections
         let countByValueType (keyf:'T->'Key) (seq:seq<'T>) = seq |> countByImpl HashIdentity.Structural<'Key> keyf id
 
         // Wrap a StructBox around all keys in case the key type is itself a type using null as a representation
-        let countByRefType   (keyf:'T->'Key) (seq:seq<'T>) = seq |> countByImpl StructBox<'Key>.Comparer (fun t -> StructBox (keyf t)) (fun sb -> sb.Value)
+        let countByRefType   (keyf:'T->'Key) (seq:seq<'T>) = seq |> countByImpl RuntimeHelpers.StructBox<'Key>.Comparer (fun t -> RuntimeHelpers.StructBox (keyf t)) (fun sb -> sb.Value)
 
         [<CompiledName("CountBy")>]
         let countBy (keyf:'T->'Key) (source:seq<'T>) =
@@ -2391,7 +714,7 @@ namespace Microsoft.FSharp.Collections
         let inline sum (source:seq<'a>) : 'a =
             source
             |> foreach (fun _ ->
-                { new Composer.Internal.Folder<'a,'a> (LanguagePrimitives.GenericZero) with
+                { new Composer.Core.Folder<'a,'a> (LanguagePrimitives.GenericZero) with
                     override this.ProcessNext value =
                         this.Value <- Checked.(+) this.Value value
                         Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
@@ -2401,7 +724,7 @@ namespace Microsoft.FSharp.Collections
         let inline sumBy (f : 'T -> ^U) (source: seq<'T>) : ^U =
             source
             |> foreach (fun _ ->
-                { new Composer.Internal.Folder<'T,'U> (LanguagePrimitives.GenericZero< ^U>) with
+                { new Composer.Core.Folder<'T,'U> (LanguagePrimitives.GenericZero< ^U>) with
                     override this.ProcessNext value =
                         this.Value <- Checked.(+) this.Value (f value)
                         Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
@@ -2411,7 +734,7 @@ namespace Microsoft.FSharp.Collections
         let inline average (source: seq< ^a>) : ^a =
             source
             |> foreach (fun _ ->
-                { new Composer.Internal.Folder<'a, Composer.Internal.Values<'a, int>> (Composer.Internal.Values<_,_>(LanguagePrimitives.GenericZero, 0)) with
+                { new Composer.Core.Folder<'a, Composer.Core.Values<'a, int>> (Composer.Core.Values<_,_>(LanguagePrimitives.GenericZero, 0)) with
                     override this.ProcessNext value =
                         this.Value._1 <- Checked.(+) this.Value._1 value
                         this.Value._2 <- this.Value._2 + 1
@@ -2426,7 +749,7 @@ namespace Microsoft.FSharp.Collections
         let inline averageBy (f : 'T -> ^U) (source: seq< 'T >) : ^U =
             source
             |> foreach (fun _ ->
-                { new Composer.Internal.Folder<'T,Composer.Internal.Values<'U, int>> (Composer.Internal.Values<_,_>(LanguagePrimitives.GenericZero, 0)) with
+                { new Composer.Core.Folder<'T,Composer.Core.Values<'U, int>> (Composer.Core.Values<_,_>(LanguagePrimitives.GenericZero, 0)) with
                     override this.ProcessNext value =
                         this.Value._1 <- Checked.(+) this.Value._1 (f value)
                         this.Value._2 <- this.Value._2 + 1
@@ -2441,7 +764,7 @@ namespace Microsoft.FSharp.Collections
         let inline min (source: seq<_>) =
             source
             |> foreach (fun _ ->
-                { new Composer.Internal.Folder<'T,Composer.Internal.Values<bool,'T>> (Composer.Internal.Values<_,_>(true, Unchecked.defaultof<'T>)) with
+                { new Composer.Core.Folder<'T,Composer.Core.Values<bool,'T>> (Composer.Core.Values<_,_>(true, Unchecked.defaultof<'T>)) with
                     override this.ProcessNext value =
                         if this.Value._1 then
                             this.Value._1 <- false
@@ -2460,7 +783,7 @@ namespace Microsoft.FSharp.Collections
         let inline minBy (f : 'T -> 'U) (source: seq<'T>) : 'T =
             source
             |> foreach (fun _ ->
-                { new Composer.Internal.Folder<'T,Composer.Internal.Values<bool,'U,'T>> (Composer.Internal.Values<_,_,_>(true,Unchecked.defaultof<'U>,Unchecked.defaultof<'T>)) with
+                { new Composer.Core.Folder<'T,Composer.Core.Values<bool,'U,'T>> (Composer.Core.Values<_,_,_>(true,Unchecked.defaultof<'U>,Unchecked.defaultof<'T>)) with
                     override this.ProcessNext value =
                         match this.Value._1, f value with
                         | true, valueU ->
@@ -2499,7 +822,7 @@ namespace Microsoft.FSharp.Collections
         let inline max (source: seq<_>) =
             source
             |> foreach (fun _ ->
-                { new Composer.Internal.Folder<'T,Composer.Internal.Values<bool,'T>> (Composer.Internal.Values<_,_>(true, Unchecked.defaultof<'T>)) with
+                { new Composer.Core.Folder<'T,Composer.Core.Values<bool,'T>> (Composer.Core.Values<_,_>(true, Unchecked.defaultof<'T>)) with
                     override this.ProcessNext value =
                         if this.Value._1 then
                             this.Value._1 <- false
@@ -2518,7 +841,7 @@ namespace Microsoft.FSharp.Collections
         let inline maxBy (f : 'T -> 'U) (source: seq<'T>) : 'T =
             source
             |> foreach (fun _ ->
-                { new Composer.Internal.Folder<'T,Composer.Internal.Values<bool,'U,'T>> (Composer.Internal.Values<_,_,_>(true,Unchecked.defaultof<'U>,Unchecked.defaultof<'T>)) with
+                { new Composer.Core.Folder<'T,Composer.Core.Values<bool,'U,'T>> (Composer.Core.Values<_,_,_>(true,Unchecked.defaultof<'U>,Unchecked.defaultof<'T>)) with
                     override this.ProcessNext value =
                         match this.Value._1, f value with
                         | true, valueU ->
@@ -2556,15 +879,15 @@ namespace Microsoft.FSharp.Collections
 *)
         [<CompiledName("TakeWhile")>]
         let takeWhile p (source: seq<_>) =
-            source |> seqFactory (Composer.TakeWhileFactory p)
+            source |> seqFactory (Composer.Seq.TakeWhileFactory p)
 
         [<CompiledName("Skip")>]
         let skip count (source: seq<_>) =
-            source |> seqFactory (Composer.SkipFactory count)
+            source |> seqFactory (Composer.Seq.SkipFactory count)
 
         [<CompiledName("SkipWhile")>]
         let skipWhile p (source: seq<_>) =
-            source |> seqFactory (Composer.SkipWhileFactory p)
+            source |> seqFactory (Composer.Seq.SkipWhileFactory p)
 
         [<CompiledName("ForAll2")>]
         let forall2 p (source1: seq<_>) (source2: seq<_>) =
@@ -2575,7 +898,7 @@ namespace Microsoft.FSharp.Collections
 
             source1
             |> foreach (fun halt ->
-                { new Composer.Internal.Folder<_,bool> (true) with
+                { new Composer.Core.Folder<_,bool> (true) with
                     override this.ProcessNext value =
                         if (e2.MoveNext()) then
                             if not (p.Invoke(value, e2.Current)) then
@@ -2595,7 +918,7 @@ namespace Microsoft.FSharp.Collections
 
             source1
             |> foreach (fun halt ->
-                { new Composer.Internal.Folder<_,bool> (false) with
+                { new Composer.Core.Folder<_,bool> (false) with
                     override this.ProcessNext value =
                         if (e2.MoveNext()) then
                             if p.Invoke(value, e2.Current) then
@@ -2610,7 +933,7 @@ namespace Microsoft.FSharp.Collections
         let tryHead (source : seq<_>) =
             source
             |> foreach (fun halt ->
-                { new Composer.Internal.Folder<'T, Option<'T>> (None) with
+                { new Composer.Core.Folder<'T, Option<'T>> (None) with
                     override this.ProcessNext value =
                         this.Value <- Some value
                         halt ()
@@ -2625,13 +948,13 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("Tail")>]
         let tail (source: seq<'T>) =
-            source |> seqFactory (Composer.TailFactory ())
+            source |> seqFactory (Composer.Seq.TailFactory ())
         
         [<CompiledName("TryLast")>]
         let tryLast (source : seq<_>) =
             source
             |> foreach (fun _ ->
-                { new Composer.Internal.Folder<'T, Composer.Internal.Values<bool,'T>> (Composer.Internal.Values<bool,'T>(true, Unchecked.defaultof<'T>)) with
+                { new Composer.Core.Folder<'T, Composer.Core.Values<bool,'T>> (Composer.Core.Values<bool,'T>(true, Unchecked.defaultof<'T>)) with
                     override this.ProcessNext value =
                         if this.Value._1 then
                             this.Value._1 <- false
@@ -2653,7 +976,7 @@ namespace Microsoft.FSharp.Collections
         let exactlyOne (source : seq<_>) =
             source
             |> foreach (fun halt ->
-                { new Composer.Internal.Folder<'T, Composer.Internal.Values<bool,'T, bool>> (Composer.Internal.Values<bool,'T, bool>(true, Unchecked.defaultof<'T>, false)) with
+                { new Composer.Core.Folder<'T, Composer.Core.Values<bool,'T, bool>> (Composer.Core.Values<bool,'T, bool>(true, Unchecked.defaultof<'T>, false)) with
                     override this.ProcessNext value =
                         if this.Value._1 then
                             this.Value._1 <- false
@@ -2677,7 +1000,7 @@ namespace Microsoft.FSharp.Collections
                 let array = source |> toArray 
                 Array.Reverse array
                 array
-            Composer.Helpers.upcastEnumerable (Composer.Array.createDelayedId delayedReverse)
+            Composer.Helpers.upcastEnumerable (Composer.Seq.Array.createDelayedId delayedReverse)
 
         [<CompiledName("Permute")>]
         let permute f (source:seq<_>) =
@@ -2686,7 +1009,7 @@ namespace Microsoft.FSharp.Collections
                 source
                 |> toArray
                 |> Array.permute f
-            Composer.Helpers.upcastEnumerable (Composer.Array.createDelayedId delayedPermute)
+            Composer.Helpers.upcastEnumerable (Composer.Seq.Array.createDelayedId delayedPermute)
 
         [<CompiledName("MapFold")>]
         let mapFold<'T,'State,'Result> (f: 'State -> 'T -> 'Result * 'State) acc source =
@@ -2704,7 +1027,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Except")>]
         let except (itemsToExclude: seq<'T>) (source: seq<'T>) =
             checkNonNull "itemsToExclude" itemsToExclude
-            source |> seqFactory (Composer.ExceptFactory itemsToExclude)
+            source |> seqFactory (Composer.Seq.ExceptFactory itemsToExclude)
 
         [<CompiledName("ChunkBySize")>]
         let chunkBySize chunkSize (source : seq<_>) =

--- a/src/fsharp/FSharp.Core/seq.fsi
+++ b/src/fsharp/FSharp.Core/seq.fsi
@@ -13,75 +13,6 @@ namespace Microsoft.FSharp.Collections
     [<RequireQualifiedAccess>]
     [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
     module Seq = 
-        module Composer =
-            module Internal =
-                /// <summary>PipeIdx denotes the index of the element within the pipeline. 0 denotes the
-                /// source of the chain.</summary>
-                type PipeIdx = int
-                type ``PipeIdx?`` = Nullable<PipeIdx>
-
-                /// <summary>ICompletionChaining is used to correctly handle cleaning up of the pipeline. A
-                /// base implementation is provided in Consumer, and should not be overwritten. Consumer
-                /// provides it's own OnComplete and OnDispose function which should be used to handle
-                /// a particular consumers cleanup.</summary>
-                type ICompletionChaining =
-                    /// <summary>OnComplete is used to determine if the object has been processed correctly, 
-                    /// and possibly throw exceptions to denote incorrect application (i.e. such as a Take
-                    /// operation which didn't have a source at least as large as was required). It is
-                    /// not called in the case of an exception being thrown whilst the stream is still
-                    /// being processed.</summary>
-                    abstract OnComplete : PipeIdx -> unit
-                    /// <summary>OnDispose is used to cleanup the stream. It is always called at the last operation
-                    /// after the enumeration has completed.</summary>
-                    abstract OnDispose : unit -> unit
-
-                type IOutOfBand =
-                    abstract StopFurtherProcessing : PipeIdx -> unit
-
-                /// <summary>Consumer is the base class of all elements within the pipeline</summary>
-                [<AbstractClass>]
-                type Consumer<'T,'U> =
-                    interface ICompletionChaining
-                    new : unit -> Consumer<'T,'U>
-                    abstract member ProcessNext : input:'T -> bool
-                    abstract member OnComplete : PipeIdx -> unit
-                    abstract member OnDispose : unit -> unit
-
-                /// <summary>Values is a mutable struct. It can be embedded within the folder type
-                /// if two values are required for the calculation.</summary>
-                [<Struct; NoComparison; NoEquality>]
-                type Values<'a,'b> =
-                    new : a:'a * b:'b -> Values<'a,'b>
-                    val mutable _1: 'a
-                    val mutable _2: 'b
-
-                /// <summary>Values is a mutable struct. It can be embedded within the folder type
-                /// if three values are required for the calculation.</summary>
-                [<Struct; NoComparison; NoEquality>]
-                type Values<'a,'b,'c> =
-                    new : a:'a * b:'b * c:'c -> Values<'a,'b,'c>
-                    val mutable _1: 'a
-                    val mutable _2: 'b
-                    val mutable _3: 'c
-
-                /// <summary>Folder is a base class to assist with fold-like operations. It's intended usage
-                /// is as a base class for an object expression that will be used from within
-                /// the ForEach function.</summary>
-                [<AbstractClass>]
-                type Folder<'T,'U> =
-                    inherit Consumer<'T,'T>
-                    new : init:'U -> Folder<'T,'U>
-                    val mutable Value: 'U
-
-                type ISeqFactory<'T,'U> =
-                    abstract member Create : IOutOfBand -> ``PipeIdx?`` -> Consumer<'U,'V> -> Consumer<'T,'V>
-                    abstract member PipeIdx : PipeIdx
-
-                type ISeq<'T> =
-                    inherit System.Collections.Generic.IEnumerable<'T>
-                    abstract member Compose : ISeqFactory<'T,'U> -> ISeq<'U>
-                    abstract member ForEach : f:((unit -> unit) -> 'a) -> 'a when 'a :> Consumer<'T,'T>
-
         /// <summary>Returns a new sequence that contains the cartesian product of the two input sequences.</summary>
         /// <param name="source1">The first sequence.</param>
         /// <param name="source2">The second sequence.</param>
@@ -1273,7 +1204,7 @@ namespace Microsoft.FSharp.Collections
         ///
         /// <exception cref="System.ArgumentNullException">Thrown when the input sequence is null.</exception>
         [<CompiledName("ToComposer")>]
-        val toComposer   : source:seq<'T> -> Composer.Internal.ISeq<'T>
+        val toComposer   : source:seq<'T> -> Composer.Core.ISeq<'T>
 
         /// <summary>Builds a list from the given collection.</summary>
         ///
@@ -1420,97 +1351,3 @@ namespace Microsoft.FSharp.Collections
         /// <exception cref="System.ArgumentNullException">Thrown when any of the input sequences is null.</exception>
         [<CompiledName("Zip3")>]
         val zip3: source1:seq<'T1> -> source2:seq<'T2> -> source3:seq<'T3> -> seq<'T1 * 'T2 * 'T3>
-
-namespace Microsoft.FSharp.Core.CompilerServices
-
-    open System
-    open System.Collections
-    open System.Collections.Generic
-    open Microsoft.FSharp.Core
-    open Microsoft.FSharp.Collections
-        
-        
-    [<RequireQualifiedAccess>]
-    /// <summary>A group of functions used as part of the compiled representation of F# sequence expressions.</summary>
-    module RuntimeHelpers = 
-
-        [<Struct; NoComparison; NoEquality>]
-        type internal StructBox<'T when 'T : equality> = 
-            new : value:'T -> StructBox<'T>
-            member Value : 'T
-            static member Comparer : IEqualityComparer<StructBox<'T>>
-
-        /// <summary>The F# compiler emits calls to this function to 
-        /// implement the <c>while</c> operator for F# sequence expressions.</summary>
-        ///
-        /// <param name="guard">A function that indicates whether iteration should continue.</param>
-        /// <param name="source">The input sequence.</param>
-        ///
-        /// <returns>The result sequence.</returns>
-        val EnumerateWhile   : guard:(unit -> bool) -> source:seq<'T> -> seq<'T>
-
-        /// <summary>The F# compiler emits calls to this function to 
-        /// implement the <c>try/finally</c> operator for F# sequence expressions.</summary>
-        ///
-        /// <param name="source">The input sequence.</param>
-        /// <param name="compensation">A computation to be included in an enumerator's Dispose method.</param>
-        ///
-        /// <returns>The result sequence.</returns>
-        val EnumerateThenFinally :  source:seq<'T> -> compensation:(unit -> unit) -> seq<'T>
-        
-        /// <summary>The F# compiler emits calls to this function to implement the compiler-intrinsic
-        /// conversions from untyped System.Collections.IEnumerable sequences to typed sequences.</summary>
-        ///
-        /// <param name="create">An initializer function.</param>
-        /// <param name="moveNext">A function to iterate and test if end of sequence is reached.</param>
-        /// <param name="current">A function to retrieve the current element.</param>
-        ///
-        /// <returns>The resulting typed sequence.</returns>
-        val EnumerateFromFunctions: create:(unit -> 'T) -> moveNext:('T -> bool) -> current:('T -> 'U) -> seq<'U>
-
-        /// <summary>The F# compiler emits calls to this function to implement the <c>use</c> operator for F# sequence
-        /// expressions.</summary>
-        ///
-        /// <param name="resource">The resource to be used and disposed.</param>
-        /// <param name="source">The input sequence.</param>
-        ///
-        /// <returns>The result sequence.</returns>
-        val EnumerateUsing : resource:'T -> source:('T -> 'Collection) -> seq<'U> when 'T :> IDisposable and 'Collection :> seq<'U>
-
-        /// <summary>Creates an anonymous event with the given handlers.</summary>
-        ///
-        /// <param name="addHandler">A function to handle adding a delegate for the event to trigger.</param>
-        /// <param name="removeHandler">A function to handle removing a delegate that the event triggers.</param>
-        /// <param name="createHandler">A function to produce the delegate type the event can trigger.</param>
-        ///
-        /// <returns>The initialized event.</returns>
-        val CreateEvent : addHandler : ('Delegate -> unit) -> removeHandler : ('Delegate -> unit) -> createHandler : ((obj -> 'Args -> unit) -> 'Delegate) -> Microsoft.FSharp.Control.IEvent<'Delegate,'Args>
-
-    [<AbstractClass>]
-    /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
-    type GeneratedSequenceBase<'T> =
-        /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
-        ///
-        /// <returns>A new sequence generator for the expression.</returns>
-        new : unit -> GeneratedSequenceBase<'T>
-        /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
-        ///
-        /// <returns>A new enumerator for the sequence.</returns>
-        abstract GetFreshEnumerator : unit -> IEnumerator<'T>
-        /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
-        ///
-        /// <param name="result">A reference to the sequence.</param>
-        ///
-        /// <returns>A 0, 1, and 2 respectively indicate Stop, Yield, and Goto conditions for the sequence generator.</returns>
-        abstract GenerateNext : result:byref<IEnumerable<'T>> -> int
-        /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
-        abstract Close: unit -> unit
-        /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
-        abstract CheckClose: bool
-        /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
-        abstract LastGenerated : 'T
-        interface IEnumerable<'T> 
-        interface IEnumerable
-        interface IEnumerator<'T> 
-        interface IEnumerator 
-

--- a/src/fsharp/FSharp.Core/seqcomposer.fs
+++ b/src/fsharp/FSharp.Core/seqcomposer.fs
@@ -1,0 +1,1286 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.FSharp.Collections
+
+    open System
+    open System.Diagnostics
+    open System.Collections
+    open System.Collections.Generic
+    open System.Reflection
+    open Microsoft.FSharp.Core
+    open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
+    open Microsoft.FSharp.Core.Operators
+    open Microsoft.FSharp.Core.CompilerServices
+    open Microsoft.FSharp.Control
+    open Microsoft.FSharp.Collections
+    open Microsoft.FSharp.Primitives.Basics
+    
+    [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+    module Composer =
+        open IEnumerator
+
+        module Core =
+            type PipeIdx      = int
+            type ``PipeIdx?`` = Nullable<PipeIdx>
+            let emptyPipeIdx  = Nullable ()
+            let inline getPipeIdx (maybePipeIdx:``PipeIdx?``) = if maybePipeIdx.HasValue then maybePipeIdx.Value else 1
+            let inline makePipeIdx (pipeIdx:PipeIdx) = Nullable pipeIdx
+
+            type ICompletionChaining =
+                abstract OnComplete : PipeIdx -> unit
+                abstract OnDispose : unit -> unit
+
+            type IOutOfBand =
+                abstract StopFurtherProcessing : PipeIdx -> unit
+
+            [<AbstractClass>]
+            type Consumer<'T,'U> () =
+                abstract ProcessNext : input:'T -> bool
+
+                abstract OnComplete : PipeIdx -> unit
+                abstract OnDispose : unit -> unit
+
+                default __.OnComplete _ = ()
+                default __.OnDispose () = ()
+
+                interface ICompletionChaining with
+                    member this.OnComplete terminatingIdx =
+                        this.OnComplete terminatingIdx
+
+                    member this.OnDispose () = 
+                        try this.OnDispose ()
+                        finally ()
+
+            [<Struct; NoComparison; NoEquality>]
+            type Values<'a,'b> =
+                val mutable _1 : 'a
+                val mutable _2 : 'b
+
+                new (a:'a, b: 'b) = {
+                    _1 = a
+                    _2 = b
+                }
+
+            [<Struct; NoComparison; NoEquality>]
+            type Values<'a,'b,'c> =
+                val mutable _1 : 'a
+                val mutable _2 : 'b
+                val mutable _3 : 'c
+
+                new (a:'a, b:'b, c:'c) = {
+                    _1 = a
+                    _2 = b
+                    _3 = c
+                }
+
+            [<AbstractClass>]
+            type Folder<'T, 'U> =
+                inherit Consumer<'T,'T>
+
+                val mutable Value : 'U
+
+                new (init) = {
+                    inherit Consumer<'T,'T>()
+                    Value = init
+                }
+
+            type ISeqFactory<'T,'U> =
+                abstract PipeIdx : PipeIdx
+                abstract Create<'V> : IOutOfBand -> ``PipeIdx?`` -> Consumer<'U,'V> -> Consumer<'T,'V>
+
+            type ISeq<'T> =
+                inherit IEnumerable<'T>
+                abstract member Compose<'U> : (ISeqFactory<'T,'U>) -> ISeq<'U>
+                abstract member ForEach<'consumer when 'consumer :> Consumer<'T,'T>> : f:((unit->unit)->'consumer) -> 'consumer
+
+        open Core 
+
+        module internal Helpers =
+            // used for performance reasons; these are not recursive calls, so should be safe
+            // ** it should be noted that potential changes to the f# compiler may render this function
+            // ineffictive **
+            let inline avoidTailCall boolean = match boolean with true -> true | false -> false
+
+            // The f# compiler outputs unnecessary unbox.any calls in upcasts. If this functionality
+            // is fixed with the compiler then these functions can be removed.
+            let inline upcastSeq (t:#ISeq<'T>) : ISeq<'T> = (# "" t : ISeq<'T> #)
+            let inline upcastFactory (t:#ISeqFactory<'T,'U>) : ISeqFactory<'T,'U> = (# "" t : ISeqFactory<'T,'U> #)
+            let inline upcastEnumerable (t:#IEnumerable<'T>) : IEnumerable<'T> = (# "" t : IEnumerable<'T> #)
+            let inline upcastEnumerator (t:#IEnumerator<'T>) : IEnumerator<'T> = (# "" t : IEnumerator<'T> #)
+            let inline upcastEnumeratorNonGeneric (t:#IEnumerator) : IEnumerator = (# "" t : IEnumerator #)
+            let inline upcastICompletionChaining (t:#ICompletionChaining) : ICompletionChaining = (# "" t : ICompletionChaining #)
+
+        open Helpers
+
+        module internal Seq =
+            type [<AbstractClass>] SeqComponentFactory<'T,'U> (pipeIdx:``PipeIdx?``) =
+                new() = SeqComponentFactory<'T,'U> (emptyPipeIdx)
+                
+                interface ISeqFactory<'T,'U> with
+                    member __.PipeIdx = getPipeIdx pipeIdx
+                    member __.Create<'V> (_:IOutOfBand) (_:``PipeIdx?``) (_:Consumer<'U,'V>) : Consumer<'T,'V> = failwith "library implementation error: Create on base factory should not be called"
+
+            and ComposedFactory<'T,'U,'V> private (first:ISeqFactory<'T,'U>, second:ISeqFactory<'U,'V>, secondPipeIdx:PipeIdx) =
+                inherit SeqComponentFactory<'T,'V> (makePipeIdx secondPipeIdx)
+
+                interface ISeqFactory<'T,'V> with
+                    member this.Create<'W> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'V,'W>) : Consumer<'T,'W> =
+                        first.Create outOfBand pipeIdx (second.Create outOfBand (makePipeIdx secondPipeIdx) next)
+
+                static member Combine (first:ISeqFactory<'T,'U>) (second:ISeqFactory<'U,'V>) : ISeqFactory<'T,'V> =
+                    ComposedFactory(first, second, first.PipeIdx+1) |> upcastFactory
+
+            and ChooseFactory<'T,'U> (filter:'T->option<'U>) =
+                inherit SeqComponentFactory<'T,'U> ()
+                interface ISeqFactory<'T,'U> with
+                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'T,'V> = upcast Choose (filter, next) 
+            
+            and DistinctFactory<'T when 'T: equality> () =
+                inherit SeqComponentFactory<'T,'T> ()
+                interface ISeqFactory<'T,'T> with
+                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast Distinct (next) 
+
+            and DistinctByFactory<'T,'Key when 'Key: equality> (keyFunction:'T-> 'Key) =
+                inherit SeqComponentFactory<'T,'T> ()
+                interface ISeqFactory<'T,'T> with
+                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast DistinctBy (keyFunction, next) 
+            
+            and ExceptFactory<'T when 'T: equality> (itemsToExclude: seq<'T>) =
+                inherit SeqComponentFactory<'T,'T> ()
+                interface ISeqFactory<'T,'T> with
+                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast Except (itemsToExclude, next) 
+
+            and FilterFactory<'T> (filter:'T->bool) =
+                inherit SeqComponentFactory<'T,'T> ()
+                interface ISeqFactory<'T,'T> with
+                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> =
+                        match next with
+                        | :? SeqComponent<'T,'V> as next -> upcast next.CreateFilter filter
+                        | _ -> upcast Filter (filter, next)
+
+            and IdentityFactory<'T> () =
+                inherit SeqComponentFactory<'T,'T> ()
+                static let singleton = IdentityFactory<'T>()
+                interface ISeqFactory<'T,'T> with
+                    member __.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = next
+                static member Instance = singleton
+
+            and MapFactory<'T,'U> (map:'T->'U) =
+                inherit SeqComponentFactory<'T,'U> ()
+                interface ISeqFactory<'T,'U> with
+                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'T,'V> =
+                        match next with
+                        | :? SeqComponent<'U,'V> as next -> upcast next.CreateMap map
+                        | _ -> upcast Map<_,_,_> (map, next)
+
+            and Map2FirstFactory<'First,'Second,'U> (map:'First->'Second->'U, input2:IEnumerable<'Second>) =
+                inherit SeqComponentFactory<'First,'U> ()
+                interface ISeqFactory<'First,'U> with
+                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'First,'V> = upcast Map2First (map, input2, outOfBand, next, getPipeIdx pipeIdx)
+
+            and Map2SecondFactory<'First,'Second,'U> (map:'First->'Second->'U, input1:IEnumerable<'First>) =
+                inherit SeqComponentFactory<'Second,'U> ()
+                interface ISeqFactory<'Second,'U> with
+                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'Second,'V> = upcast Map2Second (map, input1, outOfBand, next, getPipeIdx pipeIdx)
+
+            and Map3Factory<'First,'Second,'Third,'U> (map:'First->'Second->'Third->'U, input2:IEnumerable<'Second>, input3:IEnumerable<'Third>) =
+                inherit SeqComponentFactory<'First,'U> ()
+                interface ISeqFactory<'First,'U> with
+                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'First,'V> = upcast Map3 (map, input2, input3, outOfBand, next, getPipeIdx pipeIdx)
+
+            and MapiFactory<'T,'U> (mapi:int->'T->'U) =
+                inherit SeqComponentFactory<'T,'U> ()
+                interface ISeqFactory<'T,'U> with
+                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'T,'V> = upcast Mapi (mapi, next) 
+
+            and Mapi2Factory<'First,'Second,'U> (map:int->'First->'Second->'U, input2:IEnumerable<'Second>) =
+                inherit SeqComponentFactory<'First,'U> ()
+                interface ISeqFactory<'First,'U> with
+                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'U,'V>) : Consumer<'First,'V> = upcast Mapi2 (map, input2, outOfBand, next, getPipeIdx pipeIdx)
+
+            and PairwiseFactory<'T> () =
+                inherit SeqComponentFactory<'T,'T*'T> ()
+                interface ISeqFactory<'T,'T*'T> with
+                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T*'T,'V>) : Consumer<'T,'V> = upcast Pairwise (next)
+
+            and ScanFactory<'T,'State> (folder:'State->'T->'State, initialState:'State) =
+                inherit SeqComponentFactory<'T,'State> ()
+                interface ISeqFactory<'T,'State> with
+                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'State,'V>) : Consumer<'T,'V> = upcast Scan<_,_,_> (folder, initialState, next)
+
+            and SkipFactory<'T> (count:int) =
+                inherit SeqComponentFactory<'T,'T> ()
+                interface ISeqFactory<'T,'T> with
+                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast Skip (count, next) 
+
+            and SkipWhileFactory<'T> (predicate:'T->bool) =
+                inherit SeqComponentFactory<'T,'T> ()
+                interface ISeqFactory<'T,'T> with
+                    member  this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast SkipWhile (predicate, next) 
+
+            and TakeWhileFactory<'T> (predicate:'T->bool) =
+                inherit SeqComponentFactory<'T,'T> ()
+                interface ISeqFactory<'T,'T> with
+                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast TakeWhile (predicate, outOfBand, next, getPipeIdx pipeIdx) 
+
+            and TakeFactory<'T> (count:int) =
+                inherit SeqComponentFactory<'T,'T> ()
+                interface ISeqFactory<'T,'T> with
+                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast Take (count, outOfBand, next, getPipeIdx pipeIdx) 
+            
+            and TailFactory<'T> () =
+                inherit SeqComponentFactory<'T,'T> ()
+                interface ISeqFactory<'T,'T> with
+                    member  this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast Tail<'T,'V> (next) 
+
+            and TruncateFactory<'T> (count:int) =
+                inherit SeqComponentFactory<'T,'T> ()
+                interface ISeqFactory<'T,'T> with
+                    member this.Create<'V> (outOfBand:IOutOfBand) (pipeIdx:``PipeIdx?``) (next:Consumer<'T,'V>) : Consumer<'T,'V> = upcast Truncate (count, outOfBand, next, getPipeIdx pipeIdx) 
+            
+            and WindowedFactory<'T> (windowSize:int) =
+                inherit SeqComponentFactory<'T, 'T[]> ()
+                interface ISeqFactory<'T, 'T[]> with
+                    member this.Create<'V> (_outOfBand:IOutOfBand) (_pipeIdx:``PipeIdx?``) (next:Consumer<'T[],'V>) : Consumer<'T,'V> = upcast Windowed (windowSize, next) 
+
+            and [<AbstractClass>] SeqComponent<'T,'U> (next:ICompletionChaining) =
+                inherit Consumer<'T,'U>()
+
+                // Seq.init(Infinite)? lazily uses Current. The only Composer component that can do that is Skip
+                // and it can only do it at the start of a sequence
+                abstract Skipping : unit -> bool
+
+                abstract CreateMap<'S> : map:('S->'T) -> SeqComponent<'S,'U>
+                abstract CreateFilter  : filter:('T->bool) -> SeqComponent<'T,'U>
+
+                interface ICompletionChaining with
+                    member this.OnComplete terminatingIdx =
+                        this.OnComplete terminatingIdx
+                        next.OnComplete terminatingIdx
+                    member this.OnDispose () =
+                        try     this.OnDispose ()
+                        finally next.OnDispose ()
+
+                default __.Skipping () = false
+
+                default this.CreateMap<'S> (map:'S->'T)      = upcast Map<_,_,_> (map, this) 
+                default this.CreateFilter  (filter:'T->bool) = upcast Filter (filter, this) 
+
+            and Choose<'T,'U,'V> (choose:'T->option<'U>, next:Consumer<'U,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                override __.ProcessNext (input:'T) : bool =
+                    match choose input with
+                    | Some value -> avoidTailCall (next.ProcessNext value)
+                    | None -> false
+
+            and Distinct<'T,'V when 'T: equality> (next:Consumer<'T,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                let hashSet = HashSet<'T>(HashIdentity.Structural<'T>)
+
+                override __.ProcessNext (input:'T) : bool = 
+                    if hashSet.Add input then
+                        avoidTailCall (next.ProcessNext input)
+                    else
+                        false
+
+            and DistinctBy<'T,'Key,'V when 'Key: equality> (keyFunction: 'T -> 'Key, next:Consumer<'T,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                let hashSet = HashSet<'Key>(HashIdentity.Structural<'Key>)
+
+                override __.ProcessNext (input:'T) : bool = 
+                    if hashSet.Add(keyFunction input) then
+                        avoidTailCall (next.ProcessNext input)
+                    else
+                        false
+
+            and Except<'T,'V when 'T: equality> (itemsToExclude: seq<'T>, next:Consumer<'T,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                let cached = lazy(HashSet(itemsToExclude, HashIdentity.Structural))
+
+                override __.ProcessNext (input:'T) : bool = 
+                    if cached.Value.Add input then
+                        avoidTailCall (next.ProcessNext input)
+                    else
+                        false
+
+            and Filter<'T,'V> (filter:'T->bool, next:Consumer<'T,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                override this.CreateMap<'S> (map:'S->'T) = upcast MapThenFilter<_,_,_> (map, filter, next) 
+
+                override __.ProcessNext (input:'T) : bool = 
+                    if filter input then
+                        avoidTailCall (next.ProcessNext input)
+                    else
+                        false
+
+            and FilterThenMap<'T,'U,'V> (filter:'T->bool, map:'T->'U, next:Consumer<'U,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                override __.ProcessNext (input:'T) : bool = 
+                    if filter input then
+                        avoidTailCall (next.ProcessNext (map input))
+                    else
+                        false
+
+            and Map<'T,'U,'V> (map:'T->'U, next:Consumer<'U,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                override this.CreateFilter (filter:'T->bool) = upcast FilterThenMap (filter, map, next) 
+
+                override __.ProcessNext (input:'T) : bool = 
+                    avoidTailCall (next.ProcessNext (map input))
+
+            and Map2First<'First,'Second,'U,'V> (map:'First->'Second->'U, enumerable2:IEnumerable<'Second>, outOfBand:IOutOfBand, next:Consumer<'U,'V>, pipeIdx:int) =
+                inherit SeqComponent<'First,'V>(next)
+
+                let input2 = enumerable2.GetEnumerator ()
+                let map' = OptimizedClosures.FSharpFunc<_,_,_>.Adapt map
+
+                override __.ProcessNext (input:'First) : bool =
+                    if input2.MoveNext () then
+                        avoidTailCall (next.ProcessNext (map'.Invoke (input, input2.Current)))
+                    else
+                        outOfBand.StopFurtherProcessing pipeIdx
+                        false
+
+                override __.OnDispose () =
+                    input2.Dispose ()
+
+            and Map2Second<'First,'Second,'U,'V> (map:'First->'Second->'U, enumerable1:IEnumerable<'First>, outOfBand:IOutOfBand, next:Consumer<'U,'V>, pipeIdx:int) =
+                inherit SeqComponent<'Second,'V>(next)
+
+                let input1 = enumerable1.GetEnumerator ()
+                let map' = OptimizedClosures.FSharpFunc<_,_,_>.Adapt map
+
+                override __.ProcessNext (input:'Second) : bool =
+                    if input1.MoveNext () then
+                        avoidTailCall (next.ProcessNext (map'.Invoke (input1.Current, input)))
+                    else
+                        outOfBand.StopFurtherProcessing pipeIdx
+                        false
+
+                override __.OnDispose () =
+                    input1.Dispose ()
+
+            and Map3<'First,'Second,'Third,'U,'V> (map:'First->'Second->'Third->'U, enumerable2:IEnumerable<'Second>, enumerable3:IEnumerable<'Third>, outOfBand:IOutOfBand, next:Consumer<'U,'V>, pipeIdx:int) =
+                inherit SeqComponent<'First,'V>(next)
+
+                let input2 = enumerable2.GetEnumerator ()
+                let input3 = enumerable3.GetEnumerator ()
+                let map' = OptimizedClosures.FSharpFunc<_,_,_,_>.Adapt map
+
+                override __.ProcessNext (input:'First) : bool =
+                    if input2.MoveNext () && input3.MoveNext () then
+                        avoidTailCall (next.ProcessNext (map'.Invoke (input, input2.Current, input3.Current)))
+                    else
+                        outOfBand.StopFurtherProcessing pipeIdx
+                        false
+
+                override __.OnDispose () =
+                    try     input2.Dispose ()
+                    finally input3.Dispose ()
+
+            and MapThenFilter<'T,'U,'V> (map:'T->'U, filter:'U->bool, next:Consumer<'U,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                override __.ProcessNext (input:'T) : bool = 
+                    let u = map input
+                    if filter u then
+                        avoidTailCall (next.ProcessNext u)
+                    else
+                        false
+
+            and Mapi<'T,'U,'V> (mapi:int->'T->'U, next:Consumer<'U,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                let mutable idx = 0
+                let mapi' = OptimizedClosures.FSharpFunc<_,_,_>.Adapt mapi
+
+                override __.ProcessNext (input:'T) : bool = 
+                    idx <- idx + 1
+                    avoidTailCall (next.ProcessNext (mapi'.Invoke (idx-1, input)))
+
+            and Mapi2<'First,'Second,'U,'V> (map:int->'First->'Second->'U, enumerable2:IEnumerable<'Second>, outOfBand:IOutOfBand, next:Consumer<'U,'V>, pipeIdx:int) =
+                inherit SeqComponent<'First,'V>(next)
+
+                let mutable idx = 0
+                let input2 = enumerable2.GetEnumerator ()
+                let mapi2' = OptimizedClosures.FSharpFunc<_,_,_,_>.Adapt map
+
+                override __.ProcessNext (input:'First) : bool =
+                    if input2.MoveNext () then
+                        idx <- idx + 1
+                        avoidTailCall (next.ProcessNext (mapi2'.Invoke (idx-1, input, input2.Current)))
+                    else
+                        outOfBand.StopFurtherProcessing pipeIdx
+                        false
+
+                override __.OnDispose () =
+                    input2.Dispose ()
+
+            and Pairwise<'T,'V> (next:Consumer<'T*'T,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                let mutable isFirst = true
+                let mutable lastValue = Unchecked.defaultof<'T>
+
+                override __.ProcessNext (input:'T) : bool = 
+                    if isFirst then
+                        lastValue <- input
+                        isFirst <- false
+                        false
+                    else
+                        let currentPair = lastValue, input
+                        lastValue <- input
+                        avoidTailCall (next.ProcessNext currentPair)
+
+            and Scan<'T,'State,'V> (folder:'State->'T->'State, initialState: 'State, next:Consumer<'State,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt folder
+                let mutable foldResult = initialState
+
+                override __.ProcessNext (input:'T) : bool =
+                    foldResult <- f.Invoke(foldResult, input)
+                    avoidTailCall (next.ProcessNext foldResult)
+
+            and Skip<'T,'V> (skipCount:int, next:Consumer<'T,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                let mutable count = 0
+
+                override __.Skipping () =
+                    if count < skipCount then
+                        count <- count + 1
+                        true
+                    else
+                        false
+
+                override __.ProcessNext (input:'T) : bool = 
+                    if count < skipCount then
+                        count <- count + 1
+                        false
+                    else
+                        avoidTailCall (next.ProcessNext input)
+
+                override __.OnComplete _ =
+                    if count < skipCount then
+                        let x = skipCount - count
+                        invalidOpFmt "tried to skip {0} {1} past the end of the seq"
+                            [|SR.GetString SR.notEnoughElements; x; (if x=1 then "element" else "elements")|]
+
+            and SkipWhile<'T,'V> (predicate:'T->bool, next:Consumer<'T,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                let mutable skip = true
+
+                override __.ProcessNext (input:'T) : bool = 
+                    if skip then
+                        skip <- predicate input
+                        if skip then
+                            false
+                        else
+                            avoidTailCall (next.ProcessNext input)
+                    else
+                        avoidTailCall (next.ProcessNext input)
+
+            and Take<'T,'V> (takeCount:int, outOfBand:IOutOfBand, next:Consumer<'T,'V>, pipelineIdx:int) =
+                inherit Truncate<'T, 'V>(takeCount, outOfBand, next, pipelineIdx)
+
+                override this.OnComplete terminatingIdx =
+                    if terminatingIdx < pipelineIdx && this.Count < takeCount then
+                        let x = takeCount - this.Count
+                        invalidOpFmt "tried to take {0} {1} past the end of the seq"
+                            [|SR.GetString SR.notEnoughElements; x; (if x=1 then "element" else "elements")|]
+
+            and TakeWhile<'T,'V> (predicate:'T->bool, outOfBand:IOutOfBand, next:Consumer<'T,'V>, pipeIdx:int) =
+                inherit SeqComponent<'T,'V>(next)
+
+                override __.ProcessNext (input:'T) : bool = 
+                    if predicate input then
+                        avoidTailCall (next.ProcessNext input)
+                    else
+                        outOfBand.StopFurtherProcessing pipeIdx
+                        false
+
+            and Tail<'T, 'V> (next:Consumer<'T,'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                let mutable first = true
+
+                override __.ProcessNext (input:'T) : bool =
+                    if first then
+                        first <- false
+                        false
+                    else
+                        avoidTailCall (next.ProcessNext input)
+
+                override this.OnComplete _ =
+                    if first then
+                        invalidArg "source" (SR.GetString(SR.notEnoughElements))
+
+            and Truncate<'T,'V> (truncateCount:int, outOfBand:IOutOfBand, next:Consumer<'T,'V>, pipeIdx:int) =
+                inherit SeqComponent<'T,'V>(next)
+
+                let mutable count = 0
+
+                member __.Count = count
+
+                override __.ProcessNext (input:'T) : bool = 
+                    if count < truncateCount then
+                        count <- count + 1
+                        if count = truncateCount then
+                            outOfBand.StopFurtherProcessing pipeIdx
+                        avoidTailCall (next.ProcessNext input)
+                    else
+                        outOfBand.StopFurtherProcessing pipeIdx
+                        false
+
+            and Windowed<'T,'V> (windowSize: int, next:Consumer<'T[],'V>) =
+                inherit SeqComponent<'T,'V>(next)
+
+                let circularBuffer = Array.zeroCreateUnchecked windowSize
+                let mutable idx = 0
+
+                let mutable priming = windowSize - 1
+
+                override __.ProcessNext (input:'T) : bool =
+                    circularBuffer.[idx] <- input
+                    
+                    idx <- idx + 1
+                    if idx = windowSize then
+                        idx <- 0
+
+                    if priming > 0 then
+                        priming <- priming - 1
+                        false
+                    else
+                        if windowSize < 32 then
+                            let window = Array.init windowSize (fun i -> circularBuffer.[(idx+i) % windowSize])
+                            avoidTailCall (next.ProcessNext window)
+                        else
+                            let window = Array.zeroCreateUnchecked windowSize 
+                            Array.Copy(circularBuffer, idx, window, 0, windowSize - idx)
+                            Array.Copy(circularBuffer, 0, window, windowSize - idx, idx)
+                            avoidTailCall (next.ProcessNext window)
+
+            type SeqProcessNextStates =
+            | InProcess  = 0
+            | NotStarted = 1
+            | Finished   = 2
+
+            type Result<'T>() =
+                let mutable haltedIdx = 0
+                
+                member val Current = Unchecked.defaultof<'T> with get, set
+                member val SeqState = SeqProcessNextStates.NotStarted with get, set
+                member __.HaltedIdx = haltedIdx
+
+                interface IOutOfBand with
+                    member __.StopFurtherProcessing pipeIdx = haltedIdx <- pipeIdx
+
+            // SetResult<> is used at the end of the chain of SeqComponents to assign the final value
+            type SetResult<'T> (result:Result<'T>) =
+                inherit Consumer<'T,'T>()
+
+                override __.ProcessNext (input:'T) : bool =
+                    result.Current <- input
+                    true
+
+            type OutOfBand() =
+                let mutable haltedIdx = 0
+                interface IOutOfBand with member __.StopFurtherProcessing pipeIdx = haltedIdx <- pipeIdx
+                member __.HaltedIdx = haltedIdx
+
+            module ForEach =
+                let enumerable (enumerable:IEnumerable<'T>) (outOfBand:OutOfBand) (consumer:Consumer<'T,'U>) =
+                    use enumerator = enumerable.GetEnumerator ()
+                    while (outOfBand.HaltedIdx = 0) && (enumerator.MoveNext ()) do
+                        consumer.ProcessNext enumerator.Current |> ignore
+
+                let array (array:array<'T>) (outOfBand:OutOfBand) (consumer:Consumer<'T,'U>) =
+                    let mutable idx = 0
+                    while (outOfBand.HaltedIdx = 0) && (idx < array.Length) do
+                        consumer.ProcessNext array.[idx] |> ignore
+                        idx <- idx + 1
+
+                let list (alist:list<'T>) (outOfBand:OutOfBand) (consumer:Consumer<'T,'U>) =
+                    let rec iterate lst =
+                        match outOfBand.HaltedIdx, lst with
+                        | 0, hd :: tl ->
+                            consumer.ProcessNext hd |> ignore
+                            iterate tl
+                        | _ -> ()
+                    iterate alist
+
+                let unfold (generator:'S->option<'T*'S>) state (outOfBand:OutOfBand) (consumer:Consumer<'T,'U>) = 
+                    let rec iterate current =
+                        match outOfBand.HaltedIdx, generator current with
+                        | 0, Some (item, next) ->
+                            consumer.ProcessNext item |> ignore
+                            iterate next
+                        | _ -> ()
+    
+                    iterate state
+
+                let makeIsSkipping (consumer:Consumer<'T,'U>) =
+                    match consumer with
+                    | :? SeqComponent<'T,'U> as c -> c.Skipping
+                    | _ -> fun () -> false
+
+                let init f (terminatingIdx:int) (outOfBand:OutOfBand) (consumer:Consumer<'T,'U>) =
+                    let mutable idx = -1
+                    let isSkipping = makeIsSkipping consumer
+                    let mutable maybeSkipping = true
+                    while (outOfBand.HaltedIdx = 0) && (idx < terminatingIdx) do
+                        if maybeSkipping then
+                            maybeSkipping <- isSkipping ()
+
+                        if (not maybeSkipping) then
+                            consumer.ProcessNext (f (idx+1)) |> ignore
+
+                        idx <- idx + 1
+
+                let execute (f:(unit->unit)->#Consumer<'U,'U>) (current:ISeqFactory<'T,'U>) executeOn =
+                    let pipeline = OutOfBand()
+                    let result = f (fun () -> (pipeline:>IOutOfBand).StopFurtherProcessing (current.PipeIdx+1))
+                    let consumer = current.Create pipeline emptyPipeIdx result
+                    try
+                        executeOn pipeline consumer
+                        (upcastICompletionChaining consumer).OnComplete pipeline.HaltedIdx
+                        result
+                    finally
+                        (upcastICompletionChaining consumer).OnDispose ()
+
+            module Enumerable =
+                type Empty<'T>() =
+                    let current () = failwith "library implementation error: Current should never be called"
+                    interface IEnumerator<'T> with
+                        member __.Current = current ()
+                    interface IEnumerator with
+                        member __.Current = current ()
+                        member __.MoveNext () = false
+                        member __.Reset (): unit = noReset ()
+                    interface IDisposable with
+                        member __.Dispose () = ()
+
+                type EmptyEnumerators<'T>() = 
+                    static let element : IEnumerator<'T> = upcast (new Empty<'T> ())
+                    static member Element = element
+
+                [<AbstractClass>]
+                type EnumeratorBase<'T>(result:Result<'T>, seqComponent:ICompletionChaining) =
+                    interface IDisposable with
+                        member __.Dispose() : unit =
+                            seqComponent.OnDispose ()
+
+                    interface IEnumerator with
+                        member this.Current : obj = box ((upcastEnumerator this)).Current
+                        member __.MoveNext () = failwith "library implementation error: derived class should implement (should be abstract)"
+                        member __.Reset () : unit = noReset ()
+
+                    interface IEnumerator<'T> with
+                        member __.Current =
+                            if result.SeqState = SeqProcessNextStates.InProcess then result.Current
+                            else
+                                match result.SeqState with
+                                | SeqProcessNextStates.NotStarted -> notStarted()
+                                | SeqProcessNextStates.Finished -> alreadyFinished()
+                                | _ -> failwith "library implementation error: all states should have been handled"
+
+                and [<AbstractClass>] EnumerableBase<'T> () =
+                    let derivedClassShouldImplement () =
+                        failwith "library implementation error: derived class should implement (should be abstract)"
+
+                    abstract member Append   : (seq<'T>) -> IEnumerable<'T>
+
+                    default this.Append source = upcastEnumerable (AppendEnumerable [this; source])
+
+                    interface IEnumerable with
+                        member this.GetEnumerator () : IEnumerator =
+                            let genericEnumerable = upcastEnumerable this
+                            let genericEnumerator = genericEnumerable.GetEnumerator ()
+                            upcastEnumeratorNonGeneric genericEnumerator
+
+                    interface IEnumerable<'T> with
+                        member this.GetEnumerator () : IEnumerator<'T> = derivedClassShouldImplement ()
+
+                    interface ISeq<'T> with
+                        member __.Compose _ = derivedClassShouldImplement ()
+                        member __.ForEach _ = derivedClassShouldImplement ()
+
+                and Enumerator<'T,'U>(source:IEnumerator<'T>, seqComponent:Consumer<'T,'U>, result:Result<'U>) =
+                    inherit EnumeratorBase<'U>(result, seqComponent)
+
+                    let rec moveNext () =
+                        if (result.HaltedIdx = 0) && source.MoveNext () then
+                            if seqComponent.ProcessNext source.Current then
+                                true
+                            else
+                                moveNext ()
+                        else
+                            result.SeqState <- SeqProcessNextStates.Finished
+                            (upcastICompletionChaining seqComponent).OnComplete result.HaltedIdx
+                            false
+
+                    interface IEnumerator with
+                        member __.MoveNext () =
+                            result.SeqState <- SeqProcessNextStates.InProcess
+                            moveNext ()
+
+                    interface IDisposable with
+                        member __.Dispose() =
+                            try
+                                source.Dispose ()
+                            finally
+                                (upcastICompletionChaining seqComponent).OnDispose ()
+
+                and Enumerable<'T,'U>(enumerable:IEnumerable<'T>, current:ISeqFactory<'T,'U>) =
+                    inherit EnumerableBase<'U>()
+
+                    interface IEnumerable<'U> with
+                        member this.GetEnumerator () : IEnumerator<'U> =
+                            let result = Result<'U> ()
+                            upcastEnumerator (new Enumerator<'T,'U>(enumerable.GetEnumerator(), current.Create result emptyPipeIdx (SetResult<'U> result), result))
+
+                    interface ISeq<'U> with
+                        member __.Compose (next:ISeqFactory<'U,'V>) : ISeq<'V> =
+                            upcastSeq (new Enumerable<'T,'V>(enumerable, ComposedFactory.Combine current next))
+
+                        member this.ForEach (f:(unit->unit)->#Consumer<'U,'U>) =
+                            ForEach.execute f current (ForEach.enumerable enumerable)
+
+                and ConcatEnumerator<'T, 'Collection when 'Collection :> seq<'T>> (sources:seq<'Collection>) =
+                    let mutable state = SeqProcessNextStates.NotStarted
+                    let main = sources.GetEnumerator ()
+
+                    let mutable active = EmptyEnumerators.Element
+
+                    let rec moveNext () =
+                        if active.MoveNext () then
+                            true
+                        elif main.MoveNext () then
+                            active.Dispose ()
+                            active <- main.Current.GetEnumerator ()
+                            moveNext ()
+                        else
+                            state <- SeqProcessNextStates.Finished
+                            false
+
+                    interface IEnumerator<'T> with
+                        member __.Current =
+                            if state = SeqProcessNextStates.InProcess then active.Current
+                            else
+                                match state with
+                                | SeqProcessNextStates.NotStarted -> notStarted()
+                                | SeqProcessNextStates.Finished -> alreadyFinished()
+                                | _ -> failwith "library implementation error: all states should have been handled"
+
+                    interface IEnumerator with
+                        member this.Current = box ((upcastEnumerator this)).Current
+                        member __.MoveNext () =
+                            state <- SeqProcessNextStates.InProcess
+                            moveNext ()
+                        member __.Reset () = noReset ()
+
+                    interface IDisposable with
+                        member __.Dispose() =
+                            main.Dispose ()
+                            active.Dispose ()
+
+                and AppendEnumerable<'T> (sources:list<seq<'T>>) =
+                    inherit EnumerableBase<'T>()
+
+                    interface IEnumerable<'T> with
+                        member this.GetEnumerator () : IEnumerator<'T> =
+                            upcastEnumerator (new ConcatEnumerator<_,_> (sources |> List.rev))
+
+                    override this.Append source =
+                        upcastEnumerable (AppendEnumerable (source :: sources))
+
+                    interface ISeq<'T> with
+                        member this.Compose (next:ISeqFactory<'T,'U>) : ISeq<'U> =
+                            upcastSeq (Enumerable<'T,'V>(this, next))
+
+                        member this.ForEach (f:(unit->unit)->#Consumer<'T,'T>) =
+                            ForEach.execute f IdentityFactory.Instance (ForEach.enumerable this)
+
+                and ConcatEnumerable<'T, 'Collection when 'Collection :> seq<'T>> (sources:seq<'Collection>) =
+                    inherit EnumerableBase<'T>()
+
+                    interface IEnumerable<'T> with
+                        member this.GetEnumerator () : IEnumerator<'T> =
+                            upcastEnumerator (new ConcatEnumerator<_,_> (sources))
+
+                    interface ISeq<'T> with
+                        member this.Compose (next:ISeqFactory<'T,'U>) : ISeq<'U> =
+                            upcastSeq (Enumerable<'T,'V>(this, next))
+
+                        member this.ForEach (f:(unit->unit)->#Consumer<'T,'T>) =
+                            ForEach.execute f IdentityFactory.Instance (ForEach.enumerable this)
+
+                let create enumerable current =
+                    upcastSeq (Enumerable(enumerable, current))
+
+            module EmptyEnumerable =
+                type Enumerable<'T> () =
+                    inherit Enumerable.EnumerableBase<'T>()
+
+                    static let singleton = Enumerable<'T>() :> ISeq<'T>
+                    static member Instance = singleton
+
+                    interface IEnumerable<'T> with
+                        member this.GetEnumerator () : IEnumerator<'T> = IEnumerator.Empty<'T>()
+
+                    override this.Append source =
+                        upcastEnumerable (Enumerable.Enumerable<'T,'T> (source, IdentityFactory.Instance))
+
+                    interface ISeq<'T> with
+                        member this.Compose (next:ISeqFactory<'T,'U>) : ISeq<'U> =
+                            upcastSeq (Enumerable.Enumerable<'T,'V>(this, next))
+
+                        member this.ForEach (f:(unit->unit)->#Consumer<'T,'T>) =
+                            ForEach.execute f IdentityFactory.Instance (ForEach.enumerable this)
+
+
+
+            module Array =
+                type Enumerator<'T,'U>(delayedArray:unit->array<'T>, seqComponent:Consumer<'T,'U>, result:Result<'U>) =
+                    inherit Enumerable.EnumeratorBase<'U>(result, seqComponent)
+
+                    let mutable idx = 0
+                    let mutable array = Unchecked.defaultof<_>
+
+                    let mutable initMoveNext = Unchecked.defaultof<_>
+                    do
+                        initMoveNext <-
+                            fun () ->
+                                result.SeqState <- SeqProcessNextStates.InProcess
+                                array <- delayedArray ()
+                                initMoveNext <- ignore
+
+                    let rec moveNext () =
+                        if (result.HaltedIdx = 0) && idx < array.Length then
+                            idx <- idx+1
+                            if seqComponent.ProcessNext array.[idx-1] then
+                                true
+                            else
+                                moveNext ()
+                        else
+                            result.SeqState <- SeqProcessNextStates.Finished
+                            (upcastICompletionChaining seqComponent).OnComplete result.HaltedIdx
+                            false
+
+                    interface IEnumerator with
+                        member __.MoveNext () =
+                            initMoveNext ()
+                            moveNext ()
+
+                type Enumerable<'T,'U>(delayedArray:unit->array<'T>, current:ISeqFactory<'T,'U>) =
+                    inherit Enumerable.EnumerableBase<'U>()
+
+                    interface IEnumerable<'U> with
+                        member this.GetEnumerator () : IEnumerator<'U> =
+                            let result = Result<'U> ()
+                            upcastEnumerator (new Enumerator<'T,'U>(delayedArray, current.Create result emptyPipeIdx (SetResult<'U> result), result))
+
+                    interface ISeq<'U> with
+                        member __.Compose (next:ISeqFactory<'U,'V>) : ISeq<'V> =
+                            upcastSeq (new Enumerable<'T,'V>(delayedArray, ComposedFactory.Combine current next))
+
+                        member this.ForEach (f:(unit->unit)->#Consumer<'U,'U>) =
+                            ForEach.execute f current (ForEach.array (delayedArray ()))
+
+                let createDelayed (delayedArray:unit->array<'T>) (current:ISeqFactory<'T,'U>) =
+                    upcastSeq (Enumerable(delayedArray, current))
+
+                let create (array:array<'T>) (current:ISeqFactory<'T,'U>) =
+                    createDelayed (fun () -> array) current
+
+                let createDelayedId (delayedArray:unit -> array<'T>) =
+                    createDelayed delayedArray IdentityFactory.Instance
+
+                let createId (array:array<'T>) =
+                    create array IdentityFactory.Instance
+
+            module List =
+                type Enumerator<'T,'U>(alist:list<'T>, seqComponent:Consumer<'T,'U>, result:Result<'U>) =
+                    inherit Enumerable.EnumeratorBase<'U>(result, seqComponent)
+
+                    let mutable list = alist
+
+                    let rec moveNext current =
+                        match result.HaltedIdx, current with
+                        | 0, head::tail -> 
+                            if seqComponent.ProcessNext head then
+                                list <- tail
+                                true
+                            else
+                                moveNext tail
+                        | _ ->
+                            result.SeqState <- SeqProcessNextStates.Finished
+                            (upcastICompletionChaining seqComponent).OnComplete result.HaltedIdx
+                            false
+
+                    interface IEnumerator with
+                        member __.MoveNext () =
+                            result.SeqState <- SeqProcessNextStates.InProcess
+                            moveNext list
+
+                type Enumerable<'T,'U>(alist:list<'T>, current:ISeqFactory<'T,'U>) =
+                    inherit Enumerable.EnumerableBase<'U>()
+
+                    interface IEnumerable<'U> with
+                        member this.GetEnumerator () : IEnumerator<'U> =
+                            let result = Result<'U> ()
+                            upcastEnumerator (new Enumerator<'T,'U>(alist, current.Create result emptyPipeIdx (SetResult<'U> result), result))
+
+                    interface ISeq<'U> with
+                        member __.Compose (next:ISeqFactory<'U,'V>) : ISeq<'V> =
+                            upcastSeq (new Enumerable<'T,'V>(alist, ComposedFactory.Combine current next))
+
+                        member this.ForEach (f:(unit->unit)->#Consumer<'U,'U>) =
+                            ForEach.execute f current (ForEach.list alist)
+
+                let create alist current =
+                    upcastSeq (Enumerable(alist, current))
+
+            module Unfold =
+                type Enumerator<'T,'U,'State>(generator:'State->option<'T*'State>, state:'State, seqComponent:Consumer<'T,'U>, result:Result<'U>) =
+                    inherit Enumerable.EnumeratorBase<'U>(result, seqComponent)
+
+                    let mutable current = state
+
+                    let rec moveNext () =
+                        match result.HaltedIdx, generator current with
+                        | 0, Some (item, nextState) ->
+                            current <- nextState
+                            if seqComponent.ProcessNext item then
+                                true
+                            else
+                                moveNext ()
+                        | _ -> false
+
+                    interface IEnumerator with
+                        member __.MoveNext () =
+                            result.SeqState <- SeqProcessNextStates.InProcess
+                            moveNext ()
+
+                type Enumerable<'T,'U,'GeneratorState>(generator:'GeneratorState->option<'T*'GeneratorState>, state:'GeneratorState, current:ISeqFactory<'T,'U>) =
+                    inherit Enumerable.EnumerableBase<'U>()
+
+                    interface IEnumerable<'U> with
+                        member this.GetEnumerator () : IEnumerator<'U> =
+                            let result = Result<'U> ()
+                            upcastEnumerator (new Enumerator<'T,'U,'GeneratorState>(generator, state, current.Create result emptyPipeIdx (SetResult<'U> result), result))
+
+                    interface ISeq<'U> with
+                        member this.Compose (next:ISeqFactory<'U,'V>) : ISeq<'V> =
+                            upcastSeq (new Enumerable<'T,'V,'GeneratorState>(generator, state, ComposedFactory.Combine current next))
+
+                        member this.ForEach (f:(unit->unit)->#Consumer<'U,'U>) =
+                            ForEach.execute f current (ForEach.unfold generator state)
+
+            module Init =
+                // The original implementation of "init" delayed the calculation of Current, and so it was possible
+                // to do MoveNext without it's value being calculated.
+                // I can imagine only two scenerios where that is possibly sane, although a simple solution is readily
+                // at hand in both cases. The first is that of an expensive generator function, where you skip the
+                // first n elements. The simple solution would have just been to have a map ((+) n) as the first operation
+                // instead. The second case would be counting elements, but that is only of use if you're not filtering
+                // or mapping or doing anything else (as that would cause Current to be evaluated!) and
+                // so you already know what the count is!! Anyway, someone thought it was a good idea, so
+                // I have had to add an extra function that is used in Skip to determine if we are touching
+                // Current or not.
+
+                let getTerminatingIdx (count:Nullable<int>) =
+                    // we are offset by 1 to allow for values going up to System.Int32.MaxValue
+                    // System.Int32.MaxValue is an illegal value for the "infinite" sequence
+                    if count.HasValue then
+                        count.Value - 1
+                    else
+                        System.Int32.MaxValue
+
+                type Enumerator<'T,'U>(count:Nullable<int>, f:int->'T, seqComponent:Consumer<'T,'U>, result:Result<'U>) =
+                    inherit Enumerable.EnumeratorBase<'U>(result, seqComponent)
+
+                    let isSkipping =
+                        ForEach.makeIsSkipping seqComponent
+
+                    let terminatingIdx =
+                        getTerminatingIdx count
+
+                    let mutable maybeSkipping = true
+                    let mutable idx = -1
+
+                    let rec moveNext () =
+                        if (result.HaltedIdx = 0) && idx < terminatingIdx then
+                            idx <- idx + 1
+
+                            if maybeSkipping then
+                                // Skip can only is only checked at the start of the sequence, so once
+                                // triggered, we stay triggered.
+                                maybeSkipping <- isSkipping ()
+                    
+                            if maybeSkipping then
+                                moveNext ()
+                            elif seqComponent.ProcessNext (f idx) then
+                                true
+                            else
+                                moveNext ()
+                        elif (result.HaltedIdx = 0) && idx = System.Int32.MaxValue then
+                            raise <| System.InvalidOperationException (SR.GetString(SR.enumerationPastIntMaxValue))
+                        else
+                            result.SeqState <- SeqProcessNextStates.Finished
+                            (upcastICompletionChaining seqComponent).OnComplete result.HaltedIdx
+                            false
+
+                    interface IEnumerator with
+                        member __.MoveNext () =
+                            result.SeqState <- SeqProcessNextStates.InProcess
+                            moveNext ()
+
+                type Enumerable<'T,'U>(count:Nullable<int>, f:int->'T, current:ISeqFactory<'T,'U>) =
+                    inherit Enumerable.EnumerableBase<'U>()
+
+                    interface IEnumerable<'U> with
+                        member this.GetEnumerator () : IEnumerator<'U> =
+                            let result = Result<'U> ()
+                            upcastEnumerator (new Enumerator<'T,'U>(count, f, current.Create result emptyPipeIdx (SetResult<'U> result), result))
+
+                    interface ISeq<'U> with
+                        member this.Compose (next:ISeqFactory<'U,'V>) : ISeq<'V> =
+                            upcastSeq (new Enumerable<'T,'V>(count, f, ComposedFactory.Combine current next))
+
+                        member this.ForEach (createResult:(unit->unit)->#Consumer<'U,'U>) =
+                            let terminatingIdx = getTerminatingIdx count
+                            ForEach.execute createResult current (ForEach.init f terminatingIdx)
+
+                let upto lastOption f =
+                    match lastOption with
+                    | Some b when b<0 -> failwith "library implementation error: upto can never be called with a negative value"
+                    | _ ->
+                        let unstarted   = -1  // index value means unstarted (and no valid index)
+                        let completed   = -2  // index value means completed (and no valid index)
+                        let unreachable = -3  // index is unreachable from 0,1,2,3,...
+                        let finalIndex  = match lastOption with
+                                            | Some b -> b             // here b>=0, a valid end value.
+                                            | None   -> unreachable   // run "forever", well as far as Int32.MaxValue since indexing with a bounded type.
+                        // The Current value for a valid index is "f i".
+                        // Lazy<_> values are used as caches, to store either the result or an exception if thrown.
+                        // These "Lazy<_>" caches are created only on the first call to current and forced immediately.
+                        // The lazy creation of the cache nodes means enumerations that skip many Current values are not delayed by GC.
+                        // For example, the full enumeration of Seq.initInfinite in the tests.
+                        // state
+                        let index   = ref unstarted
+                        // a Lazy node to cache the result/exception
+                        let current = ref (Unchecked.defaultof<_>)
+                        let setIndex i = index := i; current := (Unchecked.defaultof<_>) // cache node unprimed, initialised on demand.
+                        let getCurrent() =
+                            if !index = unstarted then notStarted()
+                            if !index = completed then alreadyFinished()
+                            match box !current with
+                            | null -> current := Lazy<_>.Create(fun () -> f !index)
+                            | _ ->  ()
+                            // forced or re-forced immediately.
+                            (!current).Force()
+                        { new IEnumerator<'U> with
+                                member x.Current = getCurrent()
+                            interface IEnumerator with
+                                member x.Current = box (getCurrent())
+                                member x.MoveNext() =
+                                    if !index = completed then
+                                        false
+                                    elif !index = unstarted then
+                                        setIndex 0
+                                        true
+                                    else (
+                                        if !index = System.Int32.MaxValue then raise <| System.InvalidOperationException (SR.GetString(SR.enumerationPastIntMaxValue))
+                                        if !index = finalIndex then
+                                            false
+                                        else
+                                            setIndex (!index + 1)
+                                            true
+                                    )
+                                member self.Reset() = noReset()
+                            interface System.IDisposable with
+                                member x.Dispose() = () }
+
+                type EnumerableDecider<'T>(count:Nullable<int>, f:int->'T) =
+                    inherit Enumerable.EnumerableBase<'T>()
+
+                    interface IEnumerable<'T> with
+                        member this.GetEnumerator () : IEnumerator<'T> =
+                            // we defer back to the original implementation as, as it's quite idiomatic in it's decision
+                            // to calculate Current in a lazy fashion. I doubt anyone is really using this functionality
+                            // in the way presented, but it's possible.
+                            upto (if count.HasValue then Some (count.Value-1) else None) f
+
+                    interface ISeq<'T> with
+                        member this.Compose (next:ISeqFactory<'T,'U>) : ISeq<'U> =
+                            upcastSeq (Enumerable<'T,'V>(count, f, next))
+
+                        member this.ForEach (f:(unit->unit)->#Consumer<'T,'T>) =
+                            ForEach.execute f IdentityFactory.Instance (ForEach.enumerable (upcastEnumerable this))
+
+            [<CompiledName("ToComposer")>]
+            let toComposer (source:seq<'T>) : ISeq<'T> = 
+                checkNonNull "source" source
+                match source with
+                | :? ISeq<'T> as s -> s
+                | :? array<'T> as a -> upcastSeq (Array.Enumerable((fun () -> a), IdentityFactory.Instance))
+                | :? list<'T> as a -> upcastSeq (List.Enumerable(a, IdentityFactory.Instance))
+                | _ -> upcastSeq (Enumerable.Enumerable<'T,'T>(source, IdentityFactory.Instance))
+
+            let inline foreach f (source:ISeq<_>) =
+                source.ForEach f
+
+            let inline compose factory (source:ISeq<'T>) =
+                source.Compose factory
+
+            [<CompiledName("Empty")>]
+            let empty<'T> = EmptyEnumerable.Enumerable<'T>.Instance
+
+            [<CompiledName("Unfold")>]
+            let unfold (generator:'State->option<'T * 'State>) (state:'State) : ISeq<'T> =
+                upcastSeq (new Unfold.Enumerable<'T,'T,'State>(generator, state, IdentityFactory.Instance))
+
+            [<CompiledName("InitializeInfinite")>]
+            let initInfinite<'T> (f:int->'T) : ISeq<'T> =
+                upcastSeq (new Init.EnumerableDecider<'T>(Nullable (), f))
+
+            [<CompiledName("Initialize")>]
+            let init<'T> (count:int) (f:int->'T) : ISeq<'T> =
+                if count < 0 then invalidArgInputMustBeNonNegative "count" count
+                elif count = 0 then empty else
+                upcastSeq (new Init.EnumerableDecider<'T>(Nullable count, f))
+
+            [<CompiledName("Iterate")>]
+            let iter f (source:ISeq<'T>) =
+                source
+                |> foreach (fun _ ->
+                    { new Consumer<'T,'T> () with
+                        override this.ProcessNext value =
+                            f value
+                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
+                |> ignore
+
+            [<CompiledName("TryItem")>]
+            let tryItem i (source:ISeq<'T>) =
+                if i < 0 then None else
+                source 
+                |> foreach (fun halt ->
+                    { new Folder<'T, Values<int, Option<'T>>> (Values<_,_> (0, None)) with
+                        override this.ProcessNext value =
+                            if this.Value._1 = i then
+                                this.Value._2 <- Some value
+                                halt ()
+                            else
+                                this.Value._1 <- this.Value._1 + 1
+                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
+                |> fun item -> item.Value._2
+
+            [<CompiledName("IterateIndexed")>]
+            let iteri f (source:ISeq<'T>) =
+                let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt f
+
+                source
+                |> foreach (fun _ ->
+                    { new Folder<'T, int> (0) with
+                        override this.ProcessNext value =
+                            f.Invoke(this.Value, value)
+                            this.Value <- this.Value + 1
+                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
+                |> ignore
+
+            [<CompiledName("Exists")>]
+            let exists f (source:ISeq<'T>) =
+                source
+                |> foreach (fun halt ->
+                    { new Folder<'T, bool> (false) with
+                        override this.ProcessNext value =
+                            if f value then
+                                this.Value <- true
+                                halt ()
+                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
+                |> fun exists -> exists.Value
+
+            [<CompiledName("Contains")>]
+            let inline contains element (source:ISeq<'T>) =
+                source
+                |> foreach (fun halt ->
+                    { new Folder<'T, bool> (false) with
+                        override this.ProcessNext value =
+                            if element = value then
+                                this.Value <- true
+                                halt ()
+                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
+                |> fun contains -> contains.Value
+
+            [<CompiledName("ForAll")>]
+            let forall f (source:ISeq<'T>) =
+                source
+                |> foreach (fun halt ->
+                    { new Folder<'T, bool> (true) with
+                        override this.ProcessNext value =
+                            if not (f value) then
+                                this.Value <- false
+                                halt ()
+                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
+                |> fun forall -> forall.Value
+
+            [<CompiledName("Filter")>]
+            let filter<'T> (f:'T->bool) (source:ISeq<'T>) : ISeq<'T> =
+                source
+                |> compose (FilterFactory f)
+
+            [<CompiledName("Map")>]
+            let map<'T,'U> (f:'T->'U) (source:ISeq<'T>) : ISeq<'U> =
+                source
+                |> compose (MapFactory f)
+
+            [<CompiledName("MapIndexed")>]
+            let mapi f source =
+                source
+                |> compose (MapiFactory f)
+
+            [<CompiledName("Choose")>]
+            let choose f source =
+                source
+                |> compose (ChooseFactory f)
+
+            [<CompiledName("Indexed")>]
+            let indexed source =
+                source
+                |> compose (MapiFactory (fun i x -> i,x))
+
+            [<CompiledName("TryPick")>]
+            let tryPick f (source:ISeq<'T>)  =
+                source
+                |> foreach (fun halt ->
+                    { new Folder<'T, Option<'U>> (None) with
+                        override this.ProcessNext value =
+                            match f value with
+                            | (Some _) as some ->
+                                this.Value <- some
+                                halt ()
+                            | None -> ()
+                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
+                |> fun pick -> pick.Value
+
+            [<CompiledName("TryFind")>]
+            let tryFind f (source:ISeq<'T>)  =
+                source 
+                |> foreach (fun halt ->
+                    { new Folder<'T, Option<'T>> (None) with
+                        override this.ProcessNext value =
+                            if f value then
+                                this.Value <- Some value
+                                halt ()
+                            Unchecked.defaultof<_> (* return value unsed in ForEach context *) })
+                |> fun find -> find.Value

--- a/src/fsharp/FSharp.Core/seqcomposer.fsi
+++ b/src/fsharp/FSharp.Core/seqcomposer.fsi
@@ -1,0 +1,757 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.FSharp.Collections
+
+  open System
+  open System.Collections
+  open System.Collections.Generic
+  open Microsoft.FSharp.Core
+  open Microsoft.FSharp.Collections
+
+  [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+  module Composer =
+    module Core = 
+        /// <summary>PipeIdx denotes the index of the element within the pipeline. 0 denotes the
+        /// source of the chain.</summary>
+        type PipeIdx = int
+        type ``PipeIdx?`` = Nullable<PipeIdx>
+
+        /// <summary>ICompletionChaining is used to correctly handle cleaning up of the pipeline. A
+        /// base implementation is provided in Consumer, and should not be overwritten. Consumer
+        /// provides it's own OnComplete and OnDispose function which should be used to handle
+        /// a particular consumers cleanup.</summary>
+        type ICompletionChaining =
+            /// <summary>OnComplete is used to determine if the object has been processed correctly, 
+            /// and possibly throw exceptions to denote incorrect application (i.e. such as a Take
+            /// operation which didn't have a source at least as large as was required). It is
+            /// not called in the case of an exception being thrown whilst the stream is still
+            /// being processed.</summary>
+            abstract OnComplete : PipeIdx -> unit
+            /// <summary>OnDispose is used to cleanup the stream. It is always called at the last operation
+            /// after the enumeration has completed.</summary>
+            abstract OnDispose : unit -> unit
+
+        type IOutOfBand =
+            abstract StopFurtherProcessing : PipeIdx -> unit
+
+        /// <summary>Consumer is the base class of all elements within the pipeline</summary>
+        [<AbstractClass>]
+        type Consumer<'T,'U> =
+            interface ICompletionChaining
+            new : unit -> Consumer<'T,'U>
+            abstract member ProcessNext : input:'T -> bool
+            abstract member OnComplete : PipeIdx -> unit
+            abstract member OnDispose : unit -> unit
+            override OnComplete : PipeIdx -> unit
+            override OnDispose : unit -> unit
+
+        /// <summary>Values is a mutable struct. It can be embedded within the folder type
+        /// if two values are required for the calculation.</summary>
+        [<Struct; NoComparison; NoEquality>]
+        type Values<'a,'b> =
+            new : a:'a * b:'b -> Values<'a,'b>
+            val mutable _1: 'a
+            val mutable _2: 'b
+
+        /// <summary>Values is a mutable struct. It can be embedded within the folder type
+        /// if three values are required for the calculation.</summary>
+        [<Struct; NoComparison; NoEquality>]
+        type Values<'a,'b,'c> =
+            new : a:'a * b:'b * c:'c -> Values<'a,'b,'c>
+            val mutable _1: 'a
+            val mutable _2: 'b
+            val mutable _3: 'c
+
+        /// <summary>Folder is a base class to assist with fold-like operations. It's intended usage
+        /// is as a base class for an object expression that will be used from within
+        /// the ForEach function.</summary>
+        [<AbstractClass>]
+        type Folder<'T,'U> =
+            inherit Consumer<'T,'T>
+            new : init:'U -> Folder<'T,'U>
+            val mutable Value: 'U
+
+        type ISeqFactory<'T,'U> =
+            abstract member Create : IOutOfBand -> ``PipeIdx?`` -> Consumer<'U,'V> -> Consumer<'T,'V>
+            abstract member PipeIdx : PipeIdx
+
+        type ISeq<'T> =
+            inherit System.Collections.Generic.IEnumerable<'T>
+            abstract member Compose : ISeqFactory<'T,'U> -> ISeq<'U>
+            abstract member ForEach : f:((unit -> unit) -> 'a) -> 'a when 'a :> Consumer<'T,'T>
+
+    open Core
+
+    module internal Helpers =
+      val inline avoidTailCall : boolean:bool -> bool
+      val inline upcastSeq : t: #ISeq<'T> ->  ISeq<'T>
+      val inline upcastFactory :
+        t: #ISeqFactory<'T,'U> ->  ISeqFactory<'T,'U>
+      val inline upcastEnumerable : t:#IEnumerable<'T> -> IEnumerable<'T>
+      val inline upcastEnumerator : t:#IEnumerator<'T> ->IEnumerator<'T>
+      val inline upcastEnumeratorNonGeneric :
+        t:#IEnumerator -> IEnumerator
+      val inline upcastICompletionChaining :
+        t: #ICompletionChaining ->  ICompletionChaining
+
+    module internal Seq =
+        [<AbstractClass>]
+        type SeqComponentFactory<'T,'U> =
+          class
+            interface  ISeqFactory<'T,'U>
+            new : unit ->  SeqComponentFactory<'T,'U>
+            new : pipeIdx: ``PipeIdx?`` ->
+                     SeqComponentFactory<'T,'U>
+          end
+        and ComposedFactory<'T,'U,'V> =
+          class
+            inherit  SeqComponentFactory<'T,'V>
+            interface  ISeqFactory<'T,'V>
+            private new : first: ISeqFactory<'T,'U> *
+                          second: ISeqFactory<'U,'V> *
+                          secondPipeIdx: PipeIdx ->
+                             ComposedFactory<'T,'U,'V>
+            static member
+              Combine : first: ISeqFactory<'T,'U> ->
+                          second: ISeqFactory<'U,'V> ->
+                             ISeqFactory<'T,'V>
+          end
+        and ChooseFactory<'T,'U> =
+          class
+            inherit  SeqComponentFactory<'T,'U>
+            interface  ISeqFactory<'T,'U>
+            new : filter:('T -> 'U option) ->  ChooseFactory<'T,'U>
+          end
+        and DistinctFactory<'T when 'T : equality> =
+          class
+            inherit  SeqComponentFactory<'T,'T>
+            interface  ISeqFactory<'T,'T>
+            new : unit ->  DistinctFactory<'T>
+          end
+        and DistinctByFactory<'T,'Key when 'Key : equality> =
+          class
+            inherit  SeqComponentFactory<'T,'T>
+            interface  ISeqFactory<'T,'T>
+            new : keyFunction:('T -> 'Key) ->  DistinctByFactory<'T,'Key>
+          end
+        and ExceptFactory<'T when 'T : equality> =
+          class
+            inherit  SeqComponentFactory<'T,'T>
+            interface  ISeqFactory<'T,'T>
+            new : itemsToExclude:seq<'T> ->  ExceptFactory<'T>
+          end
+        and FilterFactory<'T> =
+          class
+            inherit  SeqComponentFactory<'T,'T>
+            interface  ISeqFactory<'T,'T>
+            new : filter:('T -> bool) ->  FilterFactory<'T>
+          end
+        and IdentityFactory<'T> =
+          class
+            inherit  SeqComponentFactory<'T,'T>
+            interface  ISeqFactory<'T,'T>
+            new : unit ->  IdentityFactory<'T>
+            static member Instance :  IdentityFactory<'T>
+          end
+        and MapFactory<'T,'U> =
+          class
+            inherit  SeqComponentFactory<'T,'U>
+            interface  ISeqFactory<'T,'U>
+            new : map:('T -> 'U) ->  MapFactory<'T,'U>
+          end
+        and Map2FirstFactory<'First,'Second,'U> =
+          class
+            inherit  SeqComponentFactory<'First,'U>
+            interface  ISeqFactory<'First,'U>
+            new : map:('First -> 'Second -> 'U) *
+                  input2:IEnumerable<'Second> ->
+                     Map2FirstFactory<'First,'Second,'U>
+          end
+        and Map2SecondFactory<'First,'Second,'U> =
+          class
+            inherit  SeqComponentFactory<'Second,'U>
+            interface  ISeqFactory<'Second,'U>
+            new : map:('First -> 'Second -> 'U) *
+                  input1:IEnumerable<'First> ->
+                     Map2SecondFactory<'First,'Second,'U>
+          end
+        and Map3Factory<'First,'Second,'Third,'U> =
+          class
+            inherit  SeqComponentFactory<'First,'U>
+            interface  ISeqFactory<'First,'U>
+            new : map:('First -> 'Second -> 'Third -> 'U) *
+                  input2:IEnumerable<'Second> *
+                  input3:IEnumerable<'Third> ->
+                     Map3Factory<'First,'Second,'Third,'U>
+          end
+        and MapiFactory<'T,'U> =
+          class
+            inherit  SeqComponentFactory<'T,'U>
+            interface  ISeqFactory<'T,'U>
+            new : mapi:(int -> 'T -> 'U) ->  MapiFactory<'T,'U>
+          end
+        and Mapi2Factory<'First,'Second,'U> =
+          class
+            inherit  SeqComponentFactory<'First,'U>
+            interface  ISeqFactory<'First,'U>
+            new : map:(int -> 'First -> 'Second -> 'U) *
+                  input2:IEnumerable<'Second> ->
+                     Mapi2Factory<'First,'Second,'U>
+          end
+        and PairwiseFactory<'T> =
+          class
+            inherit  SeqComponentFactory<'T,('T * 'T)>
+            interface  ISeqFactory<'T,('T * 'T)>
+            new : unit ->  PairwiseFactory<'T>
+          end
+        and ScanFactory<'T,'State> =
+          class
+            inherit  SeqComponentFactory<'T,'State>
+            interface  ISeqFactory<'T,'State>
+            new : folder:('State -> 'T -> 'State) * initialState:'State ->
+                     ScanFactory<'T,'State>
+          end
+        and SkipFactory<'T> =
+          class
+            inherit  SeqComponentFactory<'T,'T>
+            interface  ISeqFactory<'T,'T>
+            new : count:int ->  SkipFactory<'T>
+          end
+        and SkipWhileFactory<'T> =
+          class
+            inherit  SeqComponentFactory<'T,'T>
+            interface  ISeqFactory<'T,'T>
+            new : predicate:('T -> bool) ->  SkipWhileFactory<'T>
+          end
+        and TakeWhileFactory<'T> =
+          class
+            inherit  SeqComponentFactory<'T,'T>
+            interface  ISeqFactory<'T,'T>
+            new : predicate:('T -> bool) ->  TakeWhileFactory<'T>
+          end
+        and TakeFactory<'T> =
+          class
+            inherit  SeqComponentFactory<'T,'T>
+            interface  ISeqFactory<'T,'T>
+            new : count:int ->  TakeFactory<'T>
+          end
+        and TailFactory<'T> =
+          class
+            inherit  SeqComponentFactory<'T,'T>
+            interface  ISeqFactory<'T,'T>
+            new : unit ->  TailFactory<'T>
+          end
+        and TruncateFactory<'T> =
+          class
+            inherit  SeqComponentFactory<'T,'T>
+            interface  ISeqFactory<'T,'T>
+            new : count:int ->  TruncateFactory<'T>
+          end
+        and WindowedFactory<'T> =
+          class
+            inherit  SeqComponentFactory<'T,'T []>
+            interface  ISeqFactory<'T,'T []>
+            new : windowSize:int ->  WindowedFactory<'T>
+          end
+        and [<AbstractClass>] SeqComponent<'T,'U> =
+          class
+            inherit  Consumer<'T,'U>
+            interface  ICompletionChaining
+            new : next: ICompletionChaining ->
+                     SeqComponent<'T,'U>
+            abstract member
+              CreateFilter : filter:('T -> bool) ->  SeqComponent<'T,'U>
+            abstract member
+              CreateMap : map:('S -> 'T) ->  SeqComponent<'S,'U>
+            abstract member Skipping : unit -> bool
+            override
+              CreateFilter : filter:('T -> bool) ->  SeqComponent<'T,'U>
+            override CreateMap : map:('S -> 'T) ->  SeqComponent<'S,'U>
+            override Skipping : unit -> bool
+          end
+        and Choose<'T,'U,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : choose:('T -> 'U option) * next: Consumer<'U,'V> ->
+                     Choose<'T,'U,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        and Distinct<'T,'V when 'T : equality> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : next: Consumer<'T,'V> ->  Distinct<'T,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        and DistinctBy<'T,'Key,'V when 'Key : equality> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : keyFunction:('T -> 'Key) * next: Consumer<'T,'V> ->
+                     DistinctBy<'T,'Key,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        and Except<'T,'V when 'T : equality> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : itemsToExclude:seq<'T> * next: Consumer<'T,'V> ->
+                     Except<'T,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        and Filter<'T,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : filter:('T -> bool) * next: Consumer<'T,'V> ->
+                     Filter<'T,'V>
+            override CreateMap : map:('S -> 'T) ->  SeqComponent<'S,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        and FilterThenMap<'T,'U,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : filter:('T -> bool) * map:('T -> 'U) *
+                  next: Consumer<'U,'V> ->
+                     FilterThenMap<'T,'U,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        and Map<'T,'U,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : map:('T -> 'U) * next: Consumer<'U,'V> ->
+                     Map<'T,'U,'V>
+            override
+              CreateFilter : filter:('T -> bool) ->  SeqComponent<'T,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        and Map2First<'First,'Second,'U,'V> =
+          class
+            inherit  SeqComponent<'First,'V>
+            new : map:('First -> 'Second -> 'U) *
+                  enumerable2:IEnumerable<'Second> *
+                  outOfBand: IOutOfBand *
+                  next: Consumer<'U,'V> * pipeIdx:int ->
+                     Map2First<'First,'Second,'U,'V>
+            override OnDispose : unit -> unit
+            override ProcessNext : input:'First -> bool
+          end
+        and Map2Second<'First,'Second,'U,'V> =
+          class
+            inherit  SeqComponent<'Second,'V>
+            new : map:('First -> 'Second -> 'U) *
+                  enumerable1:IEnumerable<'First> *
+                  outOfBand: IOutOfBand *
+                  next: Consumer<'U,'V> * pipeIdx:int ->
+                     Map2Second<'First,'Second,'U,'V>
+            override OnDispose : unit -> unit
+            override ProcessNext : input:'Second -> bool
+          end
+        and Map3<'First,'Second,'Third,'U,'V> =
+          class
+            inherit  SeqComponent<'First,'V>
+            new : map:('First -> 'Second -> 'Third -> 'U) *
+                  enumerable2:IEnumerable<'Second> *
+                  enumerable3:IEnumerable<'Third> *
+                  outOfBand: IOutOfBand *
+                  next: Consumer<'U,'V> * pipeIdx:int ->
+                     Map3<'First,'Second,'Third,'U,'V>
+            override OnDispose : unit -> unit
+            override ProcessNext : input:'First -> bool
+          end
+        and MapThenFilter<'T,'U,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : map:('T -> 'U) * filter:('U -> bool) *
+                  next: Consumer<'U,'V> ->
+                     MapThenFilter<'T,'U,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        and Mapi<'T,'U,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : mapi:(int -> 'T -> 'U) * next: Consumer<'U,'V> ->
+                     Mapi<'T,'U,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        and Mapi2<'First,'Second,'U,'V> =
+          class
+            inherit  SeqComponent<'First,'V>
+            new : map:(int -> 'First -> 'Second -> 'U) *
+                  enumerable2:IEnumerable<'Second> *
+                  outOfBand: IOutOfBand *
+                  next: Consumer<'U,'V> * pipeIdx:int ->
+                     Mapi2<'First,'Second,'U,'V>
+            override OnDispose : unit -> unit
+            override ProcessNext : input:'First -> bool
+          end
+        and Pairwise<'T,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : next: Consumer<('T * 'T),'V> ->
+                     Pairwise<'T,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        and Scan<'T,'State,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : folder:('State -> 'T -> 'State) * initialState:'State *
+                  next: Consumer<'State,'V> ->
+                     Scan<'T,'State,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        and Skip<'T,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : skipCount:int * next: Consumer<'T,'V> ->
+                     Skip<'T,'V>
+            override OnComplete :  PipeIdx -> unit
+            override ProcessNext : input:'T -> bool
+            override Skipping : unit -> bool
+          end
+        and SkipWhile<'T,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : predicate:('T -> bool) * next: Consumer<'T,'V> ->
+                     SkipWhile<'T,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        and Take<'T,'V> =
+          class
+            inherit  Truncate<'T,'V>
+            new : takeCount:int * outOfBand: IOutOfBand *
+                  next: Consumer<'T,'V> * pipelineIdx:int ->
+                     Take<'T,'V>
+            override OnComplete : terminatingIdx: PipeIdx -> unit
+          end
+        and TakeWhile<'T,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : predicate:('T -> bool) * outOfBand: IOutOfBand *
+                  next: Consumer<'T,'V> * pipeIdx:int ->
+                     TakeWhile<'T,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        and Tail<'T,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : next: Consumer<'T,'V> ->  Tail<'T,'V>
+            override OnComplete :  PipeIdx -> unit
+            override ProcessNext : input:'T -> bool
+          end
+        and Truncate<'T,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : truncateCount:int * outOfBand: IOutOfBand *
+                  next: Consumer<'T,'V> * pipeIdx:int ->
+                     Truncate<'T,'V>
+            override ProcessNext : input:'T -> bool
+            member Count : int
+          end
+        and Windowed<'T,'V> =
+          class
+            inherit  SeqComponent<'T,'V>
+            new : windowSize:int * next: Consumer<'T [],'V> ->
+                     Windowed<'T,'V>
+            override ProcessNext : input:'T -> bool
+          end
+        type SeqProcessNextStates =
+          |  InProcess  =  0
+          |  NotStarted  =  1
+          |  Finished  =  2
+        type Result<'T> =
+          class
+            interface  IOutOfBand
+            new : unit ->  Result<'T>
+            member Current : 'T
+            member HaltedIdx : int
+            member SeqState :  SeqProcessNextStates
+            member Current : 'T with set
+            member SeqState :  SeqProcessNextStates with set
+          end
+        type SetResult<'T> =
+          class
+            inherit  Consumer<'T,'T>
+            new : result: Result<'T> ->  SetResult<'T>
+            override ProcessNext : input:'T -> bool
+          end
+        type OutOfBand =
+          class
+            interface  IOutOfBand
+            new : unit ->  OutOfBand
+            member HaltedIdx : int
+          end
+        module ForEach = begin
+          val enumerable :
+            enumerable:IEnumerable<'T> ->
+              outOfBand: OutOfBand ->
+                consumer: Consumer<'T,'U> -> unit
+          val array :
+            array:'T array ->
+              outOfBand: OutOfBand ->
+                consumer: Consumer<'T,'U> -> unit
+          val list :
+            alist:'T list ->
+              outOfBand: OutOfBand ->
+                consumer: Consumer<'T,'U> -> unit
+          val unfold :
+            generator:('S -> ('T * 'S) option) ->
+              state:'S ->
+                outOfBand: OutOfBand ->
+                  consumer: Consumer<'T,'U> -> unit
+          val makeIsSkipping :
+            consumer: Consumer<'T,'U> -> (unit -> bool)
+          val init :
+            f:(int -> 'T) ->
+              terminatingIdx:int ->
+                outOfBand: OutOfBand ->
+                  consumer: Consumer<'T,'U> -> unit
+          val execute :
+            f:((unit -> unit) -> 'a) ->
+              current: ISeqFactory<'T,'U> ->
+                executeOn:( OutOfBand ->  Consumer<'T,'U> ->
+                             unit) -> 'a when 'a :>  Consumer<'U,'U>
+        end
+        module Enumerable = begin
+          type Empty<'T> =
+            class
+              interface IDisposable
+              interface IEnumerator
+              interface IEnumerator<'T>
+              new : unit ->  Empty<'T>
+            end
+          type EmptyEnumerators<'T> =
+            class
+              new : unit ->  EmptyEnumerators<'T>
+              static member Element : IEnumerator<'T>
+            end
+          [<AbstractClass>]
+          type EnumeratorBase<'T> =
+            class
+              interface IEnumerator<'T>
+              interface IEnumerator
+              interface IDisposable
+              new : result: Result<'T> *
+                    seqComponent: ICompletionChaining ->
+                       EnumeratorBase<'T>
+            end
+          and [<AbstractClass>] EnumerableBase<'T> =
+            class
+              interface  ISeq<'T>
+              interface IEnumerable<'T>
+              interface IEnumerable
+              new : unit ->  EnumerableBase<'T>
+              abstract member
+                Append : seq<'T> -> IEnumerable<'T>
+              override
+                Append : source:seq<'T> -> IEnumerable<'T>
+            end
+          and Enumerator<'T,'U> =
+            class
+              inherit  EnumeratorBase<'U>
+              interface IDisposable
+              interface IEnumerator
+              new : source:IEnumerator<'T> *
+                    seqComponent: Consumer<'T,'U> *
+                    result: Result<'U> ->
+                       Enumerator<'T,'U>
+            end
+          and Enumerable<'T,'U> =
+            class
+              inherit  EnumerableBase<'U>
+              interface  ISeq<'U>
+              interface IEnumerable<'U>
+              new : enumerable:IEnumerable<'T> *
+                    current: ISeqFactory<'T,'U> ->
+                       Enumerable<'T,'U>
+            end
+          and ConcatEnumerator<'T,'Collection when 'Collection :> seq<'T>> =
+            class
+              interface IDisposable
+              interface IEnumerator
+              interface IEnumerator<'T>
+              new : sources:seq<'Collection> ->
+                       ConcatEnumerator<'T,'Collection>
+            end
+          and AppendEnumerable<'T> =
+            class
+              inherit  EnumerableBase<'T>
+              interface  ISeq<'T>
+              interface IEnumerable<'T>
+              new : sources:seq<'T> list ->  AppendEnumerable<'T>
+              override
+                Append : source:seq<'T> ->
+                           IEnumerable<'T>
+            end
+          and ConcatEnumerable<'T,'Collection when 'Collection :> seq<'T>> =
+            class
+              inherit  EnumerableBase<'T>
+              interface  ISeq<'T>
+              interface IEnumerable<'T>
+              new : sources:seq<'Collection> ->
+                       ConcatEnumerable<'T,'Collection>
+            end
+          val create :
+            enumerable:IEnumerable<'a> ->
+              current: ISeqFactory<'a,'b> ->  ISeq<'b>
+        end
+        module EmptyEnumerable = begin
+          type Enumerable<'T> =
+            class
+              inherit  Enumerable.EnumerableBase<'T>
+              interface  ISeq<'T>
+              interface IEnumerable<'T>
+              new : unit ->  Enumerable<'T>
+              override
+                Append : source:seq<'T> -> IEnumerable<'T>
+              static member Instance :  ISeq<'T>
+            end
+        end
+        module Array = begin
+          type Enumerator<'T,'U> =
+            class
+              inherit  Enumerable.EnumeratorBase<'U>
+              interface IEnumerator
+              new : delayedArray:(unit -> 'T array) *
+                    seqComponent: Consumer<'T,'U> *
+                    result: Result<'U> ->  Enumerator<'T,'U>
+            end
+          type Enumerable<'T,'U> =
+            class
+              inherit  Enumerable.EnumerableBase<'U>
+              interface  ISeq<'U>
+              interface IEnumerable<'U>
+              new : delayedArray:(unit -> 'T array) *
+                    current: ISeqFactory<'T,'U> ->
+                       Enumerable<'T,'U>
+            end
+          val createDelayed :
+            delayedArray:(unit -> 'T array) ->
+              current: ISeqFactory<'T,'U> ->  ISeq<'U>
+          val create :
+            array:'T array ->
+              current: ISeqFactory<'T,'U> ->  ISeq<'U>
+          val createDelayedId :
+            delayedArray:(unit -> 'T array) ->  ISeq<'T>
+          val createId : array:'T array ->  ISeq<'T>
+        end
+        module List = begin
+          type Enumerator<'T,'U> =
+            class
+              inherit  Enumerable.EnumeratorBase<'U>
+              interface IEnumerator
+              new : alist:'T list * seqComponent: Consumer<'T,'U> *
+                    result: Result<'U> ->  Enumerator<'T,'U>
+            end
+          type Enumerable<'T,'U> =
+            class
+              inherit  Enumerable.EnumerableBase<'U>
+              interface  ISeq<'U>
+              interface IEnumerable<'U>
+              new : alist:'T list * current: ISeqFactory<'T,'U> ->
+                       Enumerable<'T,'U>
+            end
+          val create :
+            alist:'a list ->
+              current: ISeqFactory<'a,'b> ->  ISeq<'b>
+        end
+        module Unfold = begin
+          type Enumerator<'T,'U,'State> =
+            class
+              inherit  Enumerable.EnumeratorBase<'U>
+              interface IEnumerator
+              new : generator:('State -> ('T * 'State) option) * state:'State *
+                    seqComponent: Consumer<'T,'U> *
+                    result: Result<'U> ->
+                       Enumerator<'T,'U,'State>
+            end
+          type Enumerable<'T,'U,'GeneratorState> =
+            class
+              inherit  Enumerable.EnumerableBase<'U>
+              interface  ISeq<'U>
+              interface IEnumerable<'U>
+              new : generator:('GeneratorState -> ('T * 'GeneratorState) option) *
+                    state:'GeneratorState * current: ISeqFactory<'T,'U> ->
+                       Enumerable<'T,'U,'GeneratorState>
+            end
+        end
+        module Init = begin
+          val getTerminatingIdx : count:Nullable<int> -> int
+          type Enumerator<'T,'U> =
+            class
+              inherit  Enumerable.EnumeratorBase<'U>
+              interface IEnumerator
+              new : count:Nullable<int> * f:(int -> 'T) *
+                    seqComponent: Consumer<'T,'U> *
+                    result: Result<'U> ->  Enumerator<'T,'U>
+            end
+          type Enumerable<'T,'U> =
+            class
+              inherit  Enumerable.EnumerableBase<'U>
+              interface  ISeq<'U>
+              interface IEnumerable<'U>
+              new : count:Nullable<int> * f:(int -> 'T) *
+                    current: ISeqFactory<'T,'U> ->
+                       Enumerable<'T,'U>
+            end
+          val upto :
+            lastOption:int option ->
+              f:(int -> 'U) -> IEnumerator<'U>
+          type EnumerableDecider<'T> =
+            class
+              inherit  Enumerable.EnumerableBase<'T>
+              interface  ISeq<'T>
+              interface IEnumerable<'T>
+              new : count:Nullable<int> * f:(int -> 'T) ->
+                       EnumerableDecider<'T>
+            end
+        end
+        [<CompiledNameAttribute ("ToComposer")>]
+        val toComposer : source:seq<'T> ->  ISeq<'T>
+        val inline foreach :
+          f:((unit -> unit) -> 'a) -> source: ISeq<'b> -> 'a
+            when 'a :>  Consumer<'b,'b>
+        val inline compose :
+          factory: ISeqFactory<'T,'a> ->
+            source: ISeq<'T> ->  ISeq<'a>
+        [<CompiledNameAttribute ("Empty")>]
+        val empty<'T> :  ISeq<'T>
+        [<CompiledNameAttribute ("Unfold")>]
+        val unfold :
+          generator:('State -> ('T * 'State) option) ->
+            state:'State ->  ISeq<'T>
+        [<CompiledNameAttribute ("InitializeInfinite")>]
+        val initInfinite : f:(int -> 'T) ->  ISeq<'T>
+        [<CompiledNameAttribute ("Initialize")>]
+        val init : count:int -> f:(int -> 'T) ->  ISeq<'T>
+        [<CompiledNameAttribute ("Iterate")>]
+        val iter : f:('T -> unit) -> source: ISeq<'T> -> unit
+        [<CompiledNameAttribute ("TryItem")>]
+        val tryItem : i:int -> source: ISeq<'T> -> 'T option
+        [<CompiledNameAttribute ("IterateIndexed")>]
+        val iteri : f:(int -> 'T -> unit) -> source: ISeq<'T> -> unit
+        [<CompiledNameAttribute ("Exists")>]
+        val exists : f:('T -> bool) -> source: ISeq<'T> -> bool
+        [<CompiledNameAttribute ("Contains")>]
+        val inline contains :
+          element:'T -> source: ISeq<'T> -> bool when 'T : equality
+        [<CompiledNameAttribute ("ForAll")>]
+        val forall : f:('T -> bool) -> source: ISeq<'T> -> bool
+        [<CompiledNameAttribute ("Filter")>]
+        val filter :
+          f:('T -> bool) -> source: ISeq<'T> ->  ISeq<'T>
+        [<CompiledNameAttribute ("Map")>]
+        val map :
+          f:('T -> 'U) -> source: ISeq<'T> ->  ISeq<'U>
+        [<CompiledNameAttribute ("MapIndexed")>]
+        val mapi :
+          f:(int -> 'a -> 'b) ->
+            source: ISeq<'a> ->  ISeq<'b>
+        [<CompiledNameAttribute ("Choose")>]
+        val choose :
+          f:('a -> 'b option) ->
+            source: ISeq<'a> ->  ISeq<'b>
+        [<CompiledNameAttribute ("Indexed")>]
+        val indexed : source: ISeq<'a> ->  ISeq<int * 'a>
+        [<CompiledNameAttribute ("TryPick")>]
+        val tryPick :
+          f:('T -> 'U option) -> source: ISeq<'T> -> Option<'U>
+        [<CompiledNameAttribute ("TryFind")>]
+        val tryFind : f:('T -> bool) -> source: ISeq<'T> -> Option<'T>
+

--- a/src/fsharp/FSharp.Core/seqcore.fs
+++ b/src/fsharp/FSharp.Core/seqcore.fs
@@ -1,0 +1,405 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.FSharp.Collections
+    #nowarn "52" // The value has been copied to ensure the original is not mutated by this operation
+
+    open System
+    open System.Diagnostics
+    open System.Collections
+    open System.Collections.Generic
+    open Microsoft.FSharp.Core
+    open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
+    open Microsoft.FSharp.Core.Operators
+    open Microsoft.FSharp.Control
+    open Microsoft.FSharp.Collections
+
+    module internal IEnumerator =
+
+      let noReset() = raise (new System.NotSupportedException(SR.GetString(SR.resetNotSupported)))
+      let notStarted() = raise (new System.InvalidOperationException(SR.GetString(SR.enumerationNotStarted)))
+      let alreadyFinished() = raise (new System.InvalidOperationException(SR.GetString(SR.enumerationAlreadyFinished)))
+      let check started = if not started then notStarted()
+      let dispose (r : System.IDisposable) = r.Dispose()
+
+      let cast (e : IEnumerator) : IEnumerator<'T> =
+          { new IEnumerator<'T> with
+                member x.Current = unbox<'T> e.Current
+            interface IEnumerator with
+                member x.Current = unbox<'T> e.Current :> obj
+                member x.MoveNext() = e.MoveNext()
+                member x.Reset() = noReset()
+            interface System.IDisposable with
+                member x.Dispose() =
+                    match e with
+                    | :? System.IDisposable as e -> e.Dispose()
+                    | _ -> ()   }
+
+      /// A concrete implementation of an enumerator that returns no values
+      [<Sealed>]
+      type EmptyEnumerator<'T>() =
+          let mutable started = false
+          interface IEnumerator<'T> with
+                member x.Current =
+                  check started
+                  (alreadyFinished() : 'T)
+
+          interface System.Collections.IEnumerator with
+              member x.Current =
+                  check started
+                  (alreadyFinished() : obj)
+              member x.MoveNext() =
+                  if not started then started <- true
+                  false
+              member x.Reset() = noReset()
+          interface System.IDisposable with
+                member x.Dispose() = ()
+                
+      let Empty<'T> () = (new EmptyEnumerator<'T>() :> IEnumerator<'T>)
+      [<NoEquality; NoComparison>]
+      type EmptyEnumerable<'T> =
+            | EmptyEnumerable
+            interface IEnumerable<'T> with
+                member x.GetEnumerator() = Empty<'T>()
+            interface IEnumerable with
+                member x.GetEnumerator() = (Empty<'T>() :> IEnumerator)
+
+      let readAndClear r =
+          lock r (fun () -> match !r with None -> None | Some _ as res -> r := None; res)
+
+      let generateWhileSome openf compute closef : IEnumerator<'U> =
+          let started = ref false
+          let curr = ref None
+          let state = ref (Some(openf()))
+          let getCurr() =
+              check !started
+              match !curr with None -> alreadyFinished() | Some x -> x
+          let start() = if not !started then (started := true)
+
+          let dispose() = readAndClear state |> Option.iter closef
+          let finish() = (try dispose() finally curr := None)
+          {  new IEnumerator<'U> with
+                 member x.Current = getCurr()
+             interface IEnumerator with
+                 member x.Current = box (getCurr())
+                 member x.MoveNext() =
+                     start()
+                     match !state with
+                     | None -> false (* we started, then reached the end, then got another MoveNext *)
+                     | Some s ->
+                         match (try compute s with e -> finish(); reraise()) with
+                         | None -> finish(); false
+                         | Some _ as x -> curr := x; true
+
+                 member x.Reset() = noReset()
+             interface System.IDisposable with
+                 member x.Dispose() = dispose() }
+
+      [<Sealed>]
+      type Singleton<'T>(v:'T) =
+          let mutable started = false
+          interface IEnumerator<'T> with
+                member x.Current = v
+          interface IEnumerator with
+              member x.Current = box v
+              member x.MoveNext() = if started then false else (started <- true; true)
+              member x.Reset() = noReset()
+          interface System.IDisposable with
+              member x.Dispose() = ()
+
+      let Singleton x = (new Singleton<'T>(x) :> IEnumerator<'T>)
+
+      let EnumerateThenFinally f (e : IEnumerator<'T>) =
+          { new IEnumerator<'T> with
+                member x.Current = e.Current
+            interface IEnumerator with
+                member x.Current = (e :> IEnumerator).Current
+                member x.MoveNext() = e.MoveNext()
+                member x.Reset() = noReset()
+            interface System.IDisposable with
+                member x.Dispose() =
+                    try
+                        e.Dispose()
+                    finally
+                        f()
+          }
+    
+      let inline checkNonNull argName arg =
+        match box arg with
+        | null -> nullArg argName
+        | _ -> ()
+
+      let mkSeq f =
+          { new IEnumerable<'U> with
+                member x.GetEnumerator() = f()
+            interface IEnumerable with
+                member x.GetEnumerator() = (f() :> IEnumerator) 
+          }
+
+namespace Microsoft.FSharp.Core.CompilerServices
+
+    open System
+    open System.Diagnostics
+    open Microsoft.FSharp.Core
+    open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
+    open Microsoft.FSharp.Core.Operators
+    open Microsoft.FSharp.Control
+    open Microsoft.FSharp.Collections
+    open Microsoft.FSharp.Primitives.Basics
+    open System.Collections
+    open System.Collections.Generic
+    open Microsoft.FSharp.Collections.IEnumerator
+     
+    module RuntimeHelpers =
+
+        [<Struct; NoComparison; NoEquality>]
+        type internal StructBox<'T when 'T : equality>(value:'T) =
+            member x.Value = value
+            static member Comparer =
+                let gcomparer = HashIdentity.Structural<'T>
+                { new IEqualityComparer<StructBox<'T>> with
+                       member __.GetHashCode(v) = gcomparer.GetHashCode(v.Value)
+                       member __.Equals(v1,v2) = gcomparer.Equals(v1.Value,v2.Value) }
+
+        let Generate openf compute closef =
+            mkSeq (fun () -> IEnumerator.generateWhileSome openf compute closef)
+
+        let GenerateUsing (openf : unit -> ('U :> System.IDisposable)) compute =
+            Generate openf compute (fun (s:'U) -> s.Dispose())
+
+        let EnumerateFromFunctions opener moveNext current =
+            Generate
+                opener
+                (fun x -> if moveNext x then Some(current x) else None)
+                (fun x -> match box(x) with :? System.IDisposable as id -> id.Dispose() | _ -> ())
+
+        // A family of enumerators that can have additional 'finally' actions added to the enumerator through
+        // the use of mutation. This is used to 'push' the disposal action for a 'use' into the next enumerator.
+        // For example,
+        //    seq { use x = ...
+        //          while ... }
+        // results in the 'while' loop giving an adjustable enumerator. This is then adjusted by adding the disposal action
+        // from the 'use' into the enumerator. This means that we avoid constructing a two-deep enumerator chain in this
+        // common case.
+        type IFinallyEnumerator =
+            abstract AppendFinallyAction : (unit -> unit) -> unit
+
+        /// A concrete implementation of IEnumerable that adds the given compensation to the "Dispose" chain of any
+        /// enumerators returned by the enumerable.
+        [<Sealed>]
+        type FinallyEnumerable<'T>(compensation: unit -> unit, restf: unit -> seq<'T>) =
+            interface IEnumerable<'T> with
+                member x.GetEnumerator() =
+                    try
+                        let ie = restf().GetEnumerator()
+                        match ie with
+                        | :? IFinallyEnumerator as a ->
+                            a.AppendFinallyAction(compensation)
+                            ie
+                        | _ ->
+                            IEnumerator.EnumerateThenFinally compensation ie
+                    with e ->
+                        compensation()
+                        reraise()
+            interface IEnumerable with
+                member x.GetEnumerator() = ((x :> IEnumerable<'T>).GetEnumerator() :> IEnumerator)
+
+        /// An optimized object for concatenating a sequence of enumerables
+        [<Sealed>]
+        type ConcatEnumerator<'T,'U when 'U :> seq<'T>>(sources: seq<'U>) =
+            let mutable outerEnum = sources.GetEnumerator()
+            let mutable currInnerEnum = IEnumerator.Empty()
+
+            let mutable started = false
+            let mutable finished = false
+            let mutable compensations = []
+
+            [<DefaultValue(false)>] // false = unchecked
+            val mutable private currElement : 'T
+
+            member x.Finish() =
+                finished <- true
+                try
+                    match currInnerEnum with
+                    | null -> ()
+                    | _ ->
+                        try
+                            currInnerEnum.Dispose()
+                        finally
+                            currInnerEnum <- null
+                finally
+                    try
+                        match outerEnum with
+                        | null -> ()
+                        | _ ->
+                            try
+                                outerEnum.Dispose()
+                            finally
+                                outerEnum <- null
+                    finally
+                        let rec iter comps =
+                            match comps with
+                            |   [] -> ()
+                            |   h::t ->
+                                    try h() finally iter t
+                        try
+                            compensations |> List.rev |> iter
+                        finally
+                            compensations <- []
+
+            member x.GetCurrent() =
+                IEnumerator.check started
+                if finished then IEnumerator.alreadyFinished() else x.currElement
+
+            interface IFinallyEnumerator with
+                member x.AppendFinallyAction(f) =
+                    compensations <- f :: compensations
+
+            interface IEnumerator<'T> with
+                member x.Current = x.GetCurrent()
+
+            interface IEnumerator with
+                member x.Current = box (x.GetCurrent())
+
+                member x.MoveNext() =
+                   if not started then (started <- true)
+                   if finished then false
+                   else
+                      let rec takeInner () =
+                        // check the inner list
+                        if currInnerEnum.MoveNext() then
+                            x.currElement <- currInnerEnum.Current
+                            true
+                        else
+                            // check the outer list
+                            let rec takeOuter() =
+                                if outerEnum.MoveNext() then
+                                    let ie = outerEnum.Current
+                                    // Optimization to detect the statically-allocated empty IEnumerables
+                                    match box ie with
+                                    | :? EmptyEnumerable<'T> ->
+                                         // This one is empty, just skip, don't call GetEnumerator, try again
+                                         takeOuter()
+                                    | _ ->
+                                         // OK, this one may not be empty.
+                                         // Don't forget to dispose of the enumerator for the inner list now we're done with it
+                                         currInnerEnum.Dispose()
+                                         currInnerEnum <- ie.GetEnumerator()
+                                         takeInner ()
+                                else
+                                    // We're done
+                                    x.Finish()
+                                    false
+                            takeOuter()
+                      takeInner ()
+
+                member x.Reset() = IEnumerator.noReset()
+
+            interface System.IDisposable with
+                member x.Dispose() =
+                    if not finished then
+                        x.Finish()
+
+        let EnumerateUsing (resource : 'T :> System.IDisposable) (rest: 'T -> #seq<'U>) =
+            (FinallyEnumerable((fun () -> match box resource with null -> () | _ -> resource.Dispose()),
+                               (fun () -> rest resource :> seq<_>)) :> seq<_>)
+
+        let mkConcatSeq (sources: seq<'U :> seq<'T>>) =
+            mkSeq (fun () -> new ConcatEnumerator<_,_>(sources) :> IEnumerator<'T>)
+
+        let EnumerateWhile (g : unit -> bool) (b: seq<'T>) : seq<'T> =
+            let started = ref false
+            let curr = ref None
+            let getCurr() =
+                IEnumerator.check !started
+                match !curr with None -> IEnumerator.alreadyFinished() | Some x -> x
+            let start() = if not !started then (started := true)
+
+            let finish() = (curr := None)
+            mkConcatSeq
+               (mkSeq (fun () ->
+                    { new IEnumerator<_> with
+                          member x.Current = getCurr()
+                       interface IEnumerator with
+                          member x.Current = box (getCurr())
+                          member x.MoveNext() =
+                               start()
+                               let keepGoing = (try g() with e -> finish (); reraise ()) in
+                               if keepGoing then
+                                   curr := Some(b); true
+                               else
+                                   finish(); false
+                          member x.Reset() = IEnumerator.noReset()
+                       interface System.IDisposable with
+                          member x.Dispose() = () }))
+
+        let EnumerateThenFinally (rest : seq<'T>) (compensation : unit -> unit)  =
+            (FinallyEnumerable(compensation, (fun () -> rest)) :> seq<_>)
+
+        let CreateEvent (add : 'Delegate -> unit) (remove : 'Delegate -> unit) (create : (obj -> 'Args -> unit) -> 'Delegate ) :IEvent<'Delegate,'Args> =
+            // Note, we implement each interface explicitly: this works around a bug in the CLR
+            // implementation on CompactFramework 3.7, used on Windows Phone 7
+            { new obj() with
+                  member x.ToString() = "<published event>"
+              interface IEvent<'Delegate,'Args>
+              interface IDelegateEvent<'Delegate> with
+                 member x.AddHandler(h) = add h
+                 member x.RemoveHandler(h) = remove h
+              interface System.IObservable<'Args> with
+                 member x.Subscribe(r:IObserver<'Args>) =
+                     let h = create (fun _ args -> r.OnNext(args))
+                     add h
+                     { new System.IDisposable with
+                          member x.Dispose() = remove h } }
+
+
+    [<AbstractClass>]
+    type GeneratedSequenceBase<'T>() =
+        let mutable redirectTo : GeneratedSequenceBase<'T> = Unchecked.defaultof<_>
+        let mutable redirect : bool = false
+
+        abstract GetFreshEnumerator : unit -> IEnumerator<'T>
+        abstract GenerateNext : next:byref<IEnumerable<'T>> -> int // 0 = Stop, 1 = Yield, 2 = Goto
+        abstract Close: unit -> unit
+        abstract CheckClose: bool
+        abstract LastGenerated : 'T
+
+        //[<System.Diagnostics.DebuggerNonUserCode; System.Diagnostics.DebuggerStepThroughAttribute>]
+        member x.MoveNextImpl() =
+             let active =
+                 if redirect then redirectTo
+                 else x
+             let mutable target = null
+             match active.GenerateNext(&target) with
+             | 1 ->
+                 true
+             | 2 ->
+                 match target.GetEnumerator() with
+                 | :? GeneratedSequenceBase<'T> as g when not active.CheckClose ->
+                     redirectTo <- g
+                 | e ->
+                     redirectTo <-
+                           { new GeneratedSequenceBase<'T>() with
+                                 member x.GetFreshEnumerator() = e
+                                 member x.GenerateNext(_) = if e.MoveNext() then 1 else 0
+                                 member x.Close() = try e.Dispose() finally active.Close()
+                                 member x.CheckClose = true
+                                 member x.LastGenerated = e.Current }
+                 redirect <- true
+                 x.MoveNextImpl()
+             | _ (* 0 *)  ->
+                 false
+
+        interface IEnumerable<'T> with
+            member x.GetEnumerator() = x.GetFreshEnumerator()
+        interface IEnumerable with
+            member x.GetEnumerator() = (x.GetFreshEnumerator() :> IEnumerator)
+        interface IEnumerator<'T> with
+            member x.Current = if redirect then redirectTo.LastGenerated else x.LastGenerated
+            member x.Dispose() = if redirect then redirectTo.Close() else x.Close()
+        interface IEnumerator with
+            member x.Current = box (if redirect then redirectTo.LastGenerated else x.LastGenerated)
+
+            //[<System.Diagnostics.DebuggerNonUserCode; System.Diagnostics.DebuggerStepThroughAttribute>]
+            member x.MoveNext() = x.MoveNextImpl()
+
+            member x.Reset() = raise <| new System.NotSupportedException()

--- a/src/fsharp/FSharp.Core/seqcore.fsi
+++ b/src/fsharp/FSharp.Core/seqcore.fsi
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.FSharp.Collections
+    open System
+    open System.Collections
+    open System.Collections.Generic
+    open Microsoft.FSharp.Core
+    open Microsoft.FSharp.Collections
+    module internal IEnumerator =
+        val noReset : unit -> 'a
+        val notStarted : unit -> 'a
+        val alreadyFinished : unit -> 'a
+        val check : started:bool -> unit
+        val dispose : r:System.IDisposable -> unit
+        val cast :
+            e:System.Collections.IEnumerator ->
+            System.Collections.Generic.IEnumerator<'T>
+        [<SealedAttribute ()>]
+        type EmptyEnumerator<'T> =
+            class
+            interface System.IDisposable
+            interface System.Collections.IEnumerator
+            interface System.Collections.Generic.IEnumerator<'T>
+            new : unit -> EmptyEnumerator<'T>
+            end
+        val Empty : unit -> System.Collections.Generic.IEnumerator<'T>
+        [<NoEqualityAttribute (); NoComparisonAttribute ()>]
+        type EmptyEnumerable<'T> =
+            | EmptyEnumerable
+            with
+            interface System.Collections.IEnumerable
+            interface System.Collections.Generic.IEnumerable<'T>
+            end
+
+        val readAndClear : r:'a option ref -> 'a option
+        val generateWhileSome :
+            openf:(unit -> 'a) ->
+            compute:('a -> 'U option) ->
+                closef:('a -> unit) -> System.Collections.Generic.IEnumerator<'U>
+        [<SealedAttribute ()>]
+        type Singleton<'T> =
+            class
+            interface System.IDisposable
+            interface System.Collections.IEnumerator
+            interface System.Collections.Generic.IEnumerator<'T>
+            new : v:'T -> Singleton<'T>
+            end
+        val Singleton : x:'T -> System.Collections.Generic.IEnumerator<'T>
+        val EnumerateThenFinally :
+            f:(unit -> unit) ->
+            e:System.Collections.Generic.IEnumerator<'T> ->
+                System.Collections.Generic.IEnumerator<'T>
+        val inline checkNonNull : argName:string -> arg:'a -> unit
+        val mkSeq :
+            f:(unit -> System.Collections.Generic.IEnumerator<'U>) ->
+            System.Collections.Generic.IEnumerable<'U>
+
+namespace Microsoft.FSharp.Core.CompilerServices
+
+    open System
+    open System.Collections
+    open System.Collections.Generic
+    open Microsoft.FSharp.Core
+    open Microsoft.FSharp.Collections
+        
+        
+    [<RequireQualifiedAccess>]
+    /// <summary>A group of functions used as part of the compiled representation of F# sequence expressions.</summary>
+    module RuntimeHelpers = 
+
+        [<Struct; NoComparison; NoEquality>]
+        type internal StructBox<'T when 'T : equality> = 
+            new : value:'T -> StructBox<'T>
+            member Value : 'T
+            static member Comparer : IEqualityComparer<StructBox<'T>>
+
+        /// <summary>The F# compiler emits calls to this function to 
+        /// implement the <c>while</c> operator for F# sequence expressions.</summary>
+        ///
+        /// <param name="guard">A function that indicates whether iteration should continue.</param>
+        /// <param name="source">The input sequence.</param>
+        ///
+        /// <returns>The result sequence.</returns>
+        val EnumerateWhile   : guard:(unit -> bool) -> source:seq<'T> -> seq<'T>
+
+        /// <summary>The F# compiler emits calls to this function to 
+        /// implement the <c>try/finally</c> operator for F# sequence expressions.</summary>
+        ///
+        /// <param name="source">The input sequence.</param>
+        /// <param name="compensation">A computation to be included in an enumerator's Dispose method.</param>
+        ///
+        /// <returns>The result sequence.</returns>
+        val EnumerateThenFinally :  source:seq<'T> -> compensation:(unit -> unit) -> seq<'T>
+        
+        /// <summary>The F# compiler emits calls to this function to implement the compiler-intrinsic
+        /// conversions from untyped System.Collections.IEnumerable sequences to typed sequences.</summary>
+        ///
+        /// <param name="create">An initializer function.</param>
+        /// <param name="moveNext">A function to iterate and test if end of sequence is reached.</param>
+        /// <param name="current">A function to retrieve the current element.</param>
+        ///
+        /// <returns>The resulting typed sequence.</returns>
+        val EnumerateFromFunctions: create:(unit -> 'T) -> moveNext:('T -> bool) -> current:('T -> 'U) -> seq<'U>
+
+        /// <summary>The F# compiler emits calls to this function to implement the <c>use</c> operator for F# sequence
+        /// expressions.</summary>
+        ///
+        /// <param name="resource">The resource to be used and disposed.</param>
+        /// <param name="source">The input sequence.</param>
+        ///
+        /// <returns>The result sequence.</returns>
+        val EnumerateUsing : resource:'T -> source:('T -> 'Collection) -> seq<'U> when 'T :> IDisposable and 'Collection :> seq<'U>
+
+        /// <summary>Creates an anonymous event with the given handlers.</summary>
+        ///
+        /// <param name="addHandler">A function to handle adding a delegate for the event to trigger.</param>
+        /// <param name="removeHandler">A function to handle removing a delegate that the event triggers.</param>
+        /// <param name="createHandler">A function to produce the delegate type the event can trigger.</param>
+        ///
+        /// <returns>The initialized event.</returns>
+        val CreateEvent : addHandler : ('Delegate -> unit) -> removeHandler : ('Delegate -> unit) -> createHandler : ((obj -> 'Args -> unit) -> 'Delegate) -> Microsoft.FSharp.Control.IEvent<'Delegate,'Args>
+
+    [<AbstractClass>]
+    /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
+    type GeneratedSequenceBase<'T> =
+        /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
+        ///
+        /// <returns>A new sequence generator for the expression.</returns>
+        new : unit -> GeneratedSequenceBase<'T>
+        /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
+        ///
+        /// <returns>A new enumerator for the sequence.</returns>
+        abstract GetFreshEnumerator : unit -> IEnumerator<'T>
+        /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
+        ///
+        /// <param name="result">A reference to the sequence.</param>
+        ///
+        /// <returns>A 0, 1, and 2 respectively indicate Stop, Yield, and Goto conditions for the sequence generator.</returns>
+        abstract GenerateNext : result:byref<IEnumerable<'T>> -> int
+        /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
+        abstract Close: unit -> unit
+        /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
+        abstract CheckClose: bool
+        /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>
+        abstract LastGenerated : 'T
+        interface IEnumerable<'T> 
+        interface IEnumerable
+        interface IEnumerator<'T> 
+        interface IEnumerator 
+


### PR DESCRIPTION
So this reduces the single file diff on seq.fs... Ironically the diff is too large to view for this pull request haha.

I basically pulled out a bunch of the seq functions already there as well as separate Composer to a separate module. It felt awkward modifying the Composer.Internal module when I planned on using the internal access modifier so I changed it to Composer.Core. However, I wasn't sure what to name the other composer functions so I just stuck to Composer.Seq and made that internal.